### PR TITLE
Minor fixes for docker-compose validation cmd

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -116,7 +116,7 @@ func init() {
 		"The fastly service ID to use")
 	rootCmd.Flags().StringVarP(&fastlyAPISecretPrefix, "fastly-api-secret-prefix", "A", "fastly-api-",
 		"The fastly secret prefix to use")
-	rootCmd.Flags().BoolVarP(&ignoreNonStringKeyErrors, "ignore-non-string-key-errors", "", true,
+	rootCmd.PersistentFlags().BoolVarP(&ignoreNonStringKeyErrors, "ignore-non-string-key-errors", "", true,
 		"Ignore non-string-key docker-compose errors (true by default, subject to change).")
 }
 

--- a/cmd/validate_compose.go
+++ b/cmd/validate_compose.go
@@ -15,14 +15,14 @@ var (
 
 var validateDockerCompose = &cobra.Command{
 	Use:     "docker-compose",
-	Aliases: []string{"compose", "docker", "dc"},
+	Aliases: []string{"compose", "dc"},
 	Short:   "Verify docker-compose file for compatability with this tool",
 	Run: func(cmd *cobra.Command, args []string) {
 		// @TODO: ignoreNonStringKeyErrors is `true` by default because Lagoon doesn't enforce
 		// docker-compose compliance yet
 		err := ValidateDockerCompose(dockerComposeFile, ignoreNonStringKeyErrors)
 		if err != nil {
-			fmt.Println(fmt.Sprintf("There is an issue with the docker-compose file, see errors below\n%s", err.Error()))
+			fmt.Println(err.Error())
 			os.Exit(1)
 		}
 	},


### PR DESCRIPTION
Made a flag global and changed the way errors are displayed if found