### PR TITLE
use http for dbaas-operator endpoint

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -135,7 +135,7 @@ func NewGenerator(
 	}
 
 	// get the dbaas operator http endpoint or fall back to the default
-	buildValues.DBaaSOperatorEndpoint = helpers.GetEnv("DBAAS_OPERATOR_HTTP", "dbaas.lagoon.svc:5000", debug)
+	buildValues.DBaaSOperatorEndpoint = helpers.GetEnv("DBAAS_OPERATOR_HTTP", "http://dbaas.lagoon.svc:5000", debug)
 
 	// get the project and environment variables
 	projectVariables = helpers.GetEnv("LAGOON_PROJECT_VARIABLES", projectVariables, debug)

--- a/internal/helpers/helpers_dbaas.go
+++ b/internal/helpers/helpers_dbaas.go
@@ -5,13 +5,24 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"time"
 )
 
 var httpClient = &http.Client{Timeout: 10 * time.Second}
 
+func addProtocol(url string) string {
+	if !strings.Contains(url, "https://") {
+		if !strings.Contains(url, "http://") {
+			return fmt.Sprintf("http://%s", url)
+		}
+	}
+	return url
+}
+
 func CheckDBaaSHealth(dbaasEndpoint string) error {
 	// curl --write-out "%{http_code}\n" --silent --output /dev/null "http://dbaas/healthz"
+	dbaasEndpoint = addProtocol(dbaasEndpoint)
 	resp, err := httpClient.Get(fmt.Sprintf("%s/healthz", dbaasEndpoint))
 	if err != nil {
 		return err
@@ -30,6 +41,7 @@ type DBaaSProviderResponse struct {
 // check the dbaas provider exists, will return true or false without error if it can talk to the dbaas-operator
 // will return error if there an issue with the dbaas-operator or the specified endpoint
 func CheckDBaaSProvider(dbaasEndpoint, dbaasType, dbaasEnvironment string) (bool, error) {
+	dbaasEndpoint = addProtocol(dbaasEndpoint)
 	// curl --silent "http://dbaas/type/env"
 	resp, err := httpClient.Get(fmt.Sprintf("%s/%s/%s", dbaasEndpoint, dbaasType, dbaasEnvironment))
 	if err != nil {

--- a/internal/helpers/helpers_dbaas_test.go
+++ b/internal/helpers/helpers_dbaas_test.go
@@ -108,3 +108,43 @@ func TestCheckDBaaSHealth(t *testing.T) {
 		})
 	}
 }
+
+func Test_addProtocol(t *testing.T) {
+	type args struct {
+		url string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test1",
+			args: args{
+				url: "dbaas.local.svc:5000",
+			},
+			want: "http://dbaas.local.svc:5000",
+		},
+		{
+			name: "test2",
+			args: args{
+				url: "https://dbaas.local.svc:5000",
+			},
+			want: "https://dbaas.local.svc:5000",
+		},
+		{
+			name: "test3",
+			args: args{
+				url: "http://dbaas.local.svc:5000",
+			},
+			want: "http://dbaas.local.svc:5000",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := addProtocol(tt.args.url); got != tt.want {
+				t.Errorf("addProtocol() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Unless an alternative is provided, set http as the default for the dbaas-operator endpoint