### PR TITLE
Feature: Configurable scaling options

### DIFF
--- a/cmd/tasks_run.go
+++ b/cmd/tasks_run.go
@@ -34,12 +34,12 @@ var tasksPreRun = &cobra.Command{
 	Short:   "Will run pre rollout tasks defined in .lagoon.yml",
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		lYAML, lagoonConditionalEvaluationEnvironment, err := getEnvironmentInfo(true)
+		lYAML, lagoonConditionalEvaluationEnvironment, buildValues, err := getEnvironmentInfo(true)
 		if err != nil {
 			return err
 		}
 		fmt.Println("Executing Pre-rollout Tasks")
-		err = runTasks(iterateTaskGenerator(true, runCleanTaskInEnvironment), lYAML.Tasks.Prerollout, lagoonConditionalEvaluationEnvironment)
+		err = runTasks(iterateTaskGenerator(true, runCleanTaskInEnvironment, buildValues), lYAML.Tasks.Prerollout, lagoonConditionalEvaluationEnvironment)
 		if err != nil {
 			fmt.Println("Pre-rollout Tasks Failed with the following error: " + err.Error())
 			os.Exit(1)
@@ -55,13 +55,13 @@ var tasksPostRun = &cobra.Command{
 	Short:   "Will run post rollout tasks defined in .lagoon.yml",
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		lYAML, lagoonConditionalEvaluationEnvironment, err := getEnvironmentInfo(true)
+		lYAML, lagoonConditionalEvaluationEnvironment, buildValues, err := getEnvironmentInfo(true)
 		if err != nil {
 			return err
 		}
 
 		fmt.Println("Executing Post-rollout Tasks")
-		err = runTasks(iterateTaskGenerator(false, runCleanTaskInEnvironment), lYAML.Tasks.Postrollout, lagoonConditionalEvaluationEnvironment)
+		err = runTasks(iterateTaskGenerator(false, runCleanTaskInEnvironment, buildValues), lYAML.Tasks.Postrollout, lagoonConditionalEvaluationEnvironment)
 		if err != nil {
 			fmt.Println("Post-rollout Tasks Failed with the following error: " + err.Error())
 			os.Exit(1)
@@ -71,7 +71,7 @@ var tasksPostRun = &cobra.Command{
 	},
 }
 
-func getEnvironmentInfo(debug bool) (lagoon.YAML, tasklib.TaskEnvironment, error) {
+func getEnvironmentInfo(debug bool) (lagoon.YAML, tasklib.TaskEnvironment, generator.BuildValues, error) {
 	// read the .lagoon.yml file
 	lagoonBuild, err := generator.NewGenerator(
 		lagoonYml,
@@ -105,7 +105,7 @@ func getEnvironmentInfo(debug bool) (lagoon.YAML, tasklib.TaskEnvironment, error
 		debug,
 	)
 	if err != nil {
-		return lagoon.YAML{}, nil, err
+		return lagoon.YAML{}, nil, generator.BuildValues{}, err
 	}
 
 	lagoonConditionalEvaluationEnvironment := tasklib.TaskEnvironment{}
@@ -114,7 +114,7 @@ func getEnvironmentInfo(debug bool) (lagoon.YAML, tasklib.TaskEnvironment, error
 			lagoonConditionalEvaluationEnvironment[envVar.Name] = envVar.Value
 		}
 	}
-	return *lagoonBuild.LagoonYAML, lagoonConditionalEvaluationEnvironment, nil
+	return *lagoonBuild.LagoonYAML, lagoonConditionalEvaluationEnvironment, *lagoonBuild.BuildValues, nil
 }
 
 func runTasks(taskRunner iterateTaskFuncType, tasks []lagoon.TaskRun, lagoonConditionalEvaluationEnvironment tasklib.TaskEnvironment) error {
@@ -150,7 +150,7 @@ func unwindTaskRun(taskRun []lagoon.TaskRun) []lagoon.Task {
 
 type iterateTaskFuncType func(tasklib.TaskEnvironment, []lagoon.Task) (bool, error)
 
-func iterateTaskGenerator(allowDeployMissingErrors bool, taskRunner runTaskInEnvironmentFuncType) iterateTaskFuncType {
+func iterateTaskGenerator(allowDeployMissingErrors bool, taskRunner runTaskInEnvironmentFuncType, buildValues generator.BuildValues) iterateTaskFuncType {
 	return func(lagoonConditionalEvaluationEnvironment tasklib.TaskEnvironment, tasks []lagoon.Task) (bool, error) {
 		for _, task := range tasks {
 			runTask, err := evaluateWhenConditionsForTaskInEnvironment(lagoonConditionalEvaluationEnvironment, task)
@@ -210,6 +210,8 @@ func runCleanTaskInEnvironment(incoming lagoon.Task) error {
 	task.Shell = incoming.Shell
 	task.Container = incoming.Container
 	task.Name = incoming.Name
+	task.ScaleMaxIterations = incoming.ScaleMaxIterations
+	task.ScaleWaitTime = incoming.ScaleWaitTime
 	err := lagoon.ExecuteTaskInEnvironment(task)
 	return err
 }

--- a/cmd/tasks_run_test.go
+++ b/cmd/tasks_run_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/uselagoon/build-deploy-tool/internal/generator"
 	"github.com/uselagoon/build-deploy-tool/internal/lagoon"
 	"github.com/uselagoon/build-deploy-tool/internal/tasklib"
 )
@@ -160,6 +161,7 @@ func Test_iterateTaskGenerator(t *testing.T) {
 		allowDeployMissingErrors bool
 		taskRunner               runTaskInEnvironmentFuncType
 		tasks                    []lagoon.Task
+		buildValues              generator.BuildValues
 	}
 	tests := []struct {
 		name      string
@@ -217,7 +219,7 @@ func Test_iterateTaskGenerator(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := iterateTaskGenerator(tt.args.allowDeployMissingErrors, tt.args.taskRunner)
+			got := iterateTaskGenerator(tt.args.allowDeployMissingErrors, tt.args.taskRunner, tt.args.buildValues)
 			_, err := got(tasklib.TaskEnvironment{}, tt.args.tasks)
 
 			if tt.wantError && err == nil {

--- a/internal/generator/buildvalues.go
+++ b/internal/generator/buildvalues.go
@@ -50,6 +50,8 @@ type BuildValues struct {
 	DBaaSEnvironmentTypeOverrides *lagoon.EnvironmentVariable `json:"dbaasEnvironmentTypeOverrides"`
 	DBaaSFallbackSingle           bool                        `json:"dbaasFallbackSingle"`
 	IngressClass                  string                      `json:"ingressClass"`
+	TaskScaleMaxIterations        int                         `json:"taskScaleMaxIterations"`
+	TaskScaleWaitTime             int                         `json:"taskScaleWaitTime"`
 }
 
 type MonitoringConfig struct {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -94,6 +94,10 @@ func NewGenerator(
 		return nil, err
 	}
 
+	// set the task scale iterations/wait times
+	buildValues.TaskScaleMaxIterations = helpers.GetEnvInt("LAGOON_TASK_SCALE_MAX_ITERATIONS", 30, debug)
+	buildValues.TaskScaleWaitTime = helpers.GetEnvInt("LAGOON_TASK_SCALE_WAIT_TIME", 10, debug)
+
 	// start saving values into the build values variable
 	buildValues.Project = projectName
 	buildValues.Environment = environmentName

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -95,8 +95,10 @@ func NewGenerator(
 	}
 
 	// set the task scale iterations/wait times
-	buildValues.TaskScaleMaxIterations = helpers.GetEnvInt("LAGOON_TASK_SCALE_MAX_ITERATIONS", 30, debug)
-	buildValues.TaskScaleWaitTime = helpers.GetEnvInt("LAGOON_TASK_SCALE_WAIT_TIME", 10, debug)
+	// these are not user modifiable flags, but are injectable by the controller so individual clusters can
+	// set these on their `remote-controller` deployments to be injected to builds.
+	buildValues.TaskScaleMaxIterations = helpers.GetEnvInt("LAGOON_FEATURE_FLAG_TASK_SCALE_MAX_ITERATIONS", 30, debug)
+	buildValues.TaskScaleWaitTime = helpers.GetEnvInt("LAGOON_FEATURE_FLAG_TASK_SCALE_WAIT_TIME", 10, debug)
 
 	// start saving values into the build values variable
 	buildValues.Project = projectName

--- a/internal/lagoon/tasks.go
+++ b/internal/lagoon/tasks.go
@@ -22,14 +22,16 @@ var debug bool
 
 // Task .
 type Task struct {
-	Name      string `json:"name"`
-	Command   string `json:"command"`
-	Namespace string `json:"namespace"`
-	Service   string `json:"service"`
-	Shell     string `json:"shell"`
-	Container string `json:"container"`
-	When      string `json:"when"`
-	Weight    int    `json:"weight"`
+	Name               string `json:"name"`
+	Command            string `json:"command"`
+	Namespace          string `json:"namespace"`
+	Service            string `json:"service"`
+	Shell              string `json:"shell"`
+	Container          string `json:"container"`
+	When               string `json:"when"`
+	Weight             int    `json:"weight"`
+	ScaleWaitTime      int    `json:"scaleWaitTime"`
+	ScaleMaxIterations int    `json:"scaleMaxIterations"`
 }
 
 // NewTask .
@@ -118,7 +120,7 @@ func ExecuteTaskInEnvironment(task Task) error {
 	command = append(command, "-c")
 	command = append(command, task.Command)
 
-	stdout, stderr, err := ExecPod(task.Service, task.Namespace, command, false, task.Container)
+	stdout, stderr, err := ExecPod(task.Service, task.Namespace, command, false, task.Container, task.ScaleWaitTime, task.ScaleMaxIterations)
 
 	if err != nil {
 		fmt.Printf("*** Task '%v' failed - STDOUT and STDERR follows ***\n", task.Name)
@@ -140,6 +142,7 @@ func ExecPod(
 	command []string,
 	tty bool,
 	container string,
+	waitTime, maxIterations int,
 ) (string, string, error) {
 
 	restCfg, err := getConfig()
@@ -171,13 +174,13 @@ func ExecPod(
 
 	// we want to scale the replicas here to 1, at least, before attempting the exec
 	podReady := false
-	numIterations := 0
+	numIterations := 1
 	for ; !podReady; numIterations++ {
-		if numIterations > 10 { //break if there's some reason we can't scale the pod
+		if numIterations >= maxIterations { //break if there's some reason we can't scale the pod
 			return "", "", errors.New("Failed to scale pods for " + deployment.Name)
 		}
 		if deployment.Status.ReadyReplicas == 0 {
-			fmt.Println("No ready replicas found, scaling up")
+			fmt.Println(fmt.Sprintf("No ready replicas found, scaling up. Attempt %d/%d", numIterations, maxIterations))
 
 			scale, err := clientset.AppsV1().Deployments(namespace).GetScale(context.TODO(), deployment.Name, v1.GetOptions{})
 			if err != nil {
@@ -188,8 +191,7 @@ func ExecPod(
 				scale.Spec.Replicas = 1
 				depClient.UpdateScale(context.TODO(), deployment.Name, scale, v1.UpdateOptions{})
 			}
-
-			time.Sleep(3 * time.Second)
+			time.Sleep(time.Second * time.Duration(waitTime))
 			deployment, err = depClient.Get(context.TODO(), deployment.Name, v1.GetOptions{})
 			if err != nil {
 				return "", "", err


### PR DESCRIPTION
This increases the default wait time from 3 to 10 seconds between iterations, and increases the iterations to 30 from 10.

It also adds two variables that can be added to a `remote-controller` deployment:
* `LAGOON_FEATURE_FLAG_TASK_SCALE_MAX_ITERATIONS` (integer)
* `LAGOON_FEATURE_FLAG_TASK_SCALE_WAIT_TIME` (integer)

closes #83 