### PR TITLE
Use pr-branch only checkout to maintain the git ref for PRs

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -20,8 +20,16 @@ jobs:
         - 1.17
     steps:
       -
-        name: Checkout
+        name: Checkout PR
         uses: actions/checkout@v2
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          fetch-depth: "0"
+          ref: ${{ github.event.pull_request.head.sha }}
+      -
+        name: Checkout Branch or Tag
+        uses: actions/checkout@v2
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           fetch-depth: "0"
       -


### PR DESCRIPTION
As per https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit this PR checks out the PR head instead of the merge commit, ensuring that the ref in the build commit is correct.