### PR TITLE
try connect to docker-host a few times

### DIFF
--- a/legacy/docker-entrypoint.sh
+++ b/legacy/docker-entrypoint.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
 set -e
 
-if docker -H docker-host.lagoon.svc info &> /dev/null; then
-    export DOCKER_HOST=docker-host.lagoon.svc
+# try connect to docker-host 10 times before giving up
+DOCKER_HOST_COUNTER=1
+DOCKER_HOST_TIMEOUT=10
+until docker -H docker-host.lagoon.svc info &> /dev/null
+do
+if [ $DOCKER_HOST_COUNTER -lt $DOCKER_HOST_TIMEOUT ]; then
+    let DOCKER_HOST_COUNTER=DOCKER_HOST_COUNTER+1
+    echo "docker-host.lagoon.svc not available yet, waiting for 5 secs"
+    sleep 5
 else
-    echo "could not connect to docker-host.lagoon.svc";
+    echo "could not connect to docker-host.lagoon.svc"
     exit 1
 fi
+done
+export DOCKER_HOST=docker-host.lagoon.svc
 
 mkdir -p ~/.ssh
 


### PR DESCRIPTION
After the introduction of network policies in `lagoon-remote` on the docker-host, there is a race condition where the network policy hasn't applied fully before the pod has started. This results in the docker-host check failing.

To fix this, the build should try connect to the docker-host a few times before failing.