### PR TITLE
feat: add support for default lagoon container memory limits

### DIFF
--- a/legacy/build-deploy-docker-compose.sh
+++ b/legacy/build-deploy-docker-compose.sh
@@ -767,6 +767,9 @@ yq3 write -i -- /kubectl-build-deploy/values.yaml 'gitSha' $LAGOON_GIT_SHA
 yq3 write -i -- /kubectl-build-deploy/values.yaml 'buildType' $BUILD_TYPE
 yq3 write -i -- /kubectl-build-deploy/values.yaml 'kubernetes' $KUBERNETES
 yq3 write -i -- /kubectl-build-deploy/values.yaml 'lagoonVersion' $LAGOON_VERSION
+if [ "$ADMIN_LAGOON_FEATURE_FLAG_CONTAINER_MEMORY_LIMIT" ]; then
+  yq3 write -i -- /kubectl-build-deploy/values.yaml 'resources.limits.memory' "$ADMIN_LAGOON_FEATURE_FLAG_CONTAINER_MEMORY_LIMIT"
+fi
 # check for ROOTLESS_WORKLOAD feature flag, disabled by default
 
 set +x


### PR DESCRIPTION
The intent here is to allow the remote-controller to set an environment variable on the build pod which will control the memory limit set on containers deployed by Lagoon.

This single memory limit value would be set via a flag in the remote-controller, so it would apply to _all_ containers deployed by Lagoon.

See https://github.com/uselagoon/remote-controller/pull/169 for the associated remote-controller PR.