### PR TITLE
Change: use pg_dump for postgres-single

### DIFF
--- a/legacy/helmcharts/postgres-single/templates/deployment.yaml
+++ b/legacy/helmcharts/postgres-single/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         {{- include "postgres-single.labels" . | nindent 8 }}
       annotations:
         {{- include "postgres-single.annotations" . | nindent 8 }}
-        k8up.syn.tools/backupcommand: /bin/sh -c 'tar -cf - -C {{ .Values.persistentStorage.path | quote }} --exclude="lost\+found" . || [ $? -eq 1 ]'
+        k8up.syn.tools/backupcommand: /bin/sh -c "PGPASSWORD=$POSTGRES_PASSWORD pg_dump --host=localhost --port=$POSTGRES_SERVICE_PORT --dbname=$POSTGRES_DB --username=$POSTGRES_USER --format=t -w"
         k8up.syn.tools/file-extension: .{{ include "postgres-single.fullname" . }}.tar
         lagoon.sh/configMapSha: {{ .Values.configMapSha | quote }}
     spec:

--- a/legacy/helmcharts/postgres-single/templates/deployment.yaml
+++ b/legacy/helmcharts/postgres-single/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         {{- include "postgres-single.labels" . | nindent 8 }}
       annotations:
         {{- include "postgres-single.annotations" . | nindent 8 }}
-        k8up.syn.tools/backupcommand: /bin/sh -c "PGPASSWORD=$POSTGRES_PASSWORD pg_dump --host=localhost --port=$POSTGRES_SERVICE_PORT --dbname=$POSTGRES_DB --username=$POSTGRES_USER --format=t -w"
+        k8up.syn.tools/backupcommand: /bin/sh -c "PGPASSWORD=${{ upper .Release.Name }}_PASSWORD pg_dump --host=localhost --port=${{ upper .Release.Name }}_SERVICE_PORT --dbname=${{ upper .Release.Name }}_DB --username=${{ upper .Release.Name }}_USER --format=t -w"
         k8up.syn.tools/file-extension: .{{ include "postgres-single.fullname" . }}.tar
         lagoon.sh/configMapSha: {{ .Values.configMapSha | quote }}
     spec:


### PR DESCRIPTION
`mariadb-dbaas` and `mariadb-single` both use mysqldump to produce backups

`postgres-dbaas` does pg_dump, but `postgres-single` backs up the data volume, which doesn't seem very useful in terms of being able to easily move to another database.

This brings `postgres-single` in line to use pg_dump like `postgres-dbaas`.

Unfortunately, this would mean that backups from after users deploy after this change would have a different type of backup file to restore with. But I hope this would be a welcome change for people to be able to easily restore from.