### PR TITLE
add BUILD_TARGET logic to legacy docker build

### DIFF
--- a/legacy/build-deploy-docker-compose.sh
+++ b/legacy/build-deploy-docker-compose.sh
@@ -682,6 +682,9 @@ if [[ "$BUILD_TYPE" == "pullrequest"  ||  "$BUILD_TYPE" == "branch" ]]; then
 
       BUILD_CONTEXT=$(cat $DOCKER_COMPOSE_YAML | shyaml get-value services.$IMAGE_NAME.build.context .)
 
+      # Check to see if this service uses a build target
+      BUILD_TARGET=$(cat $DOCKER_COMPOSE_YAML | shyaml get-value services.$IMAGE_NAME.build.target false)
+
       # allow to overwrite build context for this environment and service
       ENVIRONMENT_BUILD_CONTEXT_OVERRIDE=$(cat .lagoon.yml | shyaml get-value environments.${BRANCH//./\\.}.overrides.$IMAGE_NAME.build.context false)
       if [ ! $ENVIRONMENT_BUILD_CONTEXT_OVERRIDE == "false" ]; then

--- a/legacy/scripts/exec-build.sh
+++ b/legacy/scripts/exec-build.sh
@@ -2,5 +2,12 @@
 
 # try to pull the last pushed image so we can use it for --cache-from during the build
 set +x
-docker build --network=host "${BUILD_ARGS[@]}" -t $TEMPORARY_IMAGE_NAME -f $BUILD_CONTEXT/$DOCKERFILE $BUILD_CONTEXT
+
+if [ $BUILD_TARGET == "false" ]; then
+    echo "Building ${BUILD_CONTEXT}/${DOCKERFILE}"
+    docker build --network=host "${BUILD_ARGS[@]}" -t $TEMPORARY_IMAGE_NAME -f $BUILD_CONTEXT/$DOCKERFILE $BUILD_CONTEXT
+else
+    echo "Building target ${BUILD_TARGET} for ${BUILD_CONTEXT}/${DOCKERFILE}"
+    docker build --network=host "${BUILD_ARGS[@]}" -t $TEMPORARY_IMAGE_NAME -f $BUILD_CONTEXT/$DOCKERFILE --target $BUILD_TARGET $BUILD_CONTEXT
+fi
 set -x


### PR DESCRIPTION
As documented in https://docs.docker.com/engine/reference/commandline/build/#specifying-target-build-stage---target and https://docs.docker.com/compose/compose-file/build/#target developers can specify individual build-stages within a dockerfile to build a specific service from. This is particularly useful when building with concurrency (as in Buildkit)

This PR adds that functionality to the build-deploy-tool, and is triggered on receiving the `target` setting as part of the build section in a service.

closes #108 