### PR TITLE
fix: more information about container-registry credential sourcing

### DIFF
--- a/legacy/build-deploy.sh
+++ b/legacy/build-deploy.sh
@@ -95,7 +95,7 @@ fi
 ##############################################
 # we want to be able to support private container registries
 # grab all the container-registries that are defined in the `.lagoon.yml` file
-PRIVATE_CONTAINER_REGISTRIES=($(cat .lagoon.yml | shyaml keys container-registries 2> /dev/null))
+PRIVATE_CONTAINER_REGISTRIES=($(cat .lagoon.yml | shyaml keys container-registries 2> /dev/null || echo ""))
 if [ ! -z $PRIVATE_CONTAINER_REGISTRIES ]; then
   echo -e "##############################################\nBEGIN Custom Container Registries Setup\n##############################################"
   sleep 0.5s

--- a/legacy/build-deploy.sh
+++ b/legacy/build-deploy.sh
@@ -160,6 +160,11 @@ do
     fi
   fi
 done
+if [ ! -z $PRIVATE_CONTAINER_REGISTRIES ]; then
+  echo -e "##############################################\nEND Custom Container Registries Setup\n##############################################"
+  sleep 0.5s
+fi
 set -x
 
+  echo -e "##############################################\nStart Build Process\n##############################################"
 .  /kubectl-build-deploy/build-deploy-docker-compose.sh

--- a/legacy/build-deploy.sh
+++ b/legacy/build-deploy.sh
@@ -164,7 +164,7 @@ if [ ! -z $PRIVATE_CONTAINER_REGISTRIES ]; then
   echo -e "##############################################\nEND Custom Container Registries Setup\n##############################################"
   sleep 0.5s
 fi
-set -x
 
-  echo -e "##############################################\nStart Build Process\n##############################################"
+echo -e "\n\n##############################################\nStart Build Process\n##############################################"
+set -x
 .  /kubectl-build-deploy/build-deploy-docker-compose.sh

--- a/legacy/build-deploy.sh
+++ b/legacy/build-deploy.sh
@@ -29,6 +29,7 @@ else
   CI_OVERRIDE_IMAGE_REPO=""
 fi
 
+echo -e "##############################################\nBEGIN Checkout Repository\n##############################################"
 if [ "$BUILD_TYPE" == "pullrequest" ]; then
   /kubectl-build-deploy/scripts/git-checkout-pull-merge.sh "$SOURCE_REPOSITORY" "$PR_HEAD_SHA" "$PR_BASE_SHA"
 else
@@ -50,6 +51,9 @@ then
 else
   LAGOON_GIT_SHA="0000000000000000000000000000000000000000"
 fi
+
+echo -e "##############################################\nBEGIN Kubernetes and Container Registry Setup\n##############################################"
+sleep 0.5s
 
 REGISTRY_SECRETS=()
 PRIVATE_REGISTRY_COUNTER=0
@@ -91,9 +95,14 @@ fi
 ##############################################
 # we want to be able to support private container registries
 # grab all the container-registries that are defined in the `.lagoon.yml` file
-PRIVATE_CONTAINER_REGISTRIES=($(cat .lagoon.yml | shyaml keys container-registries || echo ""))
+PRIVATE_CONTAINER_REGISTRIES=($(cat .lagoon.yml | shyaml keys container-registries 2> /dev/null))
+if [ ! -z $PRIVATE_CONTAINER_REGISTRIES ]; then
+  echo -e "##############################################\nBEGIN Custom Container Registries Setup\n##############################################"
+  sleep 0.5s
+fi
 for PRIVATE_CONTAINER_REGISTRY in "${PRIVATE_CONTAINER_REGISTRIES[@]}"
 do
+  echo "Checking details for $PRIVATE_CONTAINER_REGISTRY";
   # check if a url is set, if none set proceed against docker hub
   PRIVATE_CONTAINER_REGISTRY_URL=$(cat .lagoon.yml | shyaml get-value container-registries.$PRIVATE_CONTAINER_REGISTRY.url false)
   if [ $PRIVATE_CONTAINER_REGISTRY_URL == "false" ]; then
@@ -124,13 +133,16 @@ do
     if [ -z $PRIVATE_REGISTRY_CREDENTIAL ]; then
       #if no password defined in the lagoon api, pass the one in `.lagoon.yml` as a password
       PRIVATE_REGISTRY_CREDENTIAL=$PRIVATE_CONTAINER_REGISTRY_PASSWORD
+      PRIVATE_REGISTRY_CREDENTIAL_SOURCE=".lagoon.yml (we recommend using an environment variable, see the docs on container-registries for more information)"
+    else
+      PRIVATE_REGISTRY_CREDENTIAL_SOURCE="Lagoon API variable $PRIVATE_CONTAINER_REGISTRY_PASSWORD"
     fi
     if [ -z "$PRIVATE_REGISTRY_CREDENTIAL" ]; then
       echo -e "A private container registry was defined in the .lagoon.yml file, but no password could be found in either the .lagoon.yml or in the Lagoon API\n\nPlease check if the password has been set correctly."
       exit 1
     fi
     if [ $PRIVATE_CONTAINER_REGISTRY_URL != "false" ]; then
-      echo "Attempting to log in to $PRIVATE_CONTAINER_REGISTRY_URL with user $PRIVATE_CONTAINER_REGISTRY_USERNAME - $PRIVATE_CONTAINER_REGISTRY_PASSWORD"
+      echo "Attempting to log in to $PRIVATE_CONTAINER_REGISTRY_URL with user $PRIVATE_CONTAINER_REGISTRY_USERNAME; password sourced from $PRIVATE_REGISTRY_CREDENTIAL_SOURCE"
       docker login --username $PRIVATE_CONTAINER_REGISTRY_USERNAME --password $PRIVATE_REGISTRY_CREDENTIAL $PRIVATE_CONTAINER_REGISTRY_URL
       kubectl create secret docker-registry "lagoon-private-registry-${PRIVATE_REGISTRY_COUNTER}-secret" --docker-server=$PRIVATE_CONTAINER_REGISTRY_URL --docker-username=$PRIVATE_CONTAINER_REGISTRY_USERNAME --docker-password=$PRIVATE_REGISTRY_CREDENTIAL --dry-run -o yaml | kubectl apply -f -
       REGISTRY_SECRETS+=("lagoon-private-registry-${PRIVATE_REGISTRY_COUNTER}-secret")
@@ -138,7 +150,7 @@ do
       PRIVATE_EXTERNAL_REGISTRY=1
       let ++PRIVATE_REGISTRY_COUNTER
     else
-      echo "Attempting to log in to docker hub with user $PRIVATE_CONTAINER_REGISTRY_USERNAME - $PRIVATE_CONTAINER_REGISTRY_PASSWORD"
+      echo "Attempting to log in to docker hub with user $PRIVATE_CONTAINER_REGISTRY_USERNAME; password sourced from $PRIVATE_REGISTRY_CREDENTIAL_SOURCE"
       docker login --username $PRIVATE_CONTAINER_REGISTRY_USERNAME --password $PRIVATE_REGISTRY_CREDENTIAL
       kubectl create secret docker-registry "lagoon-private-registry-${PRIVATE_REGISTRY_COUNTER}-secret" --docker-server="https://index.docker.io/v1/" --docker-username=$PRIVATE_CONTAINER_REGISTRY_USERNAME --docker-password=$PRIVATE_REGISTRY_CREDENTIAL --dry-run -o yaml | kubectl apply -f -
       REGISTRY_SECRETS+=("lagoon-private-registry-${PRIVATE_REGISTRY_COUNTER}-secret")


### PR DESCRIPTION
Just some minor changes to the output of custom container registry information to display where the credential was sourced from to aid in debugging if required.

Also adds some header separators for the UI to split up sections