### PR TITLE
Feature: Add LAGOON_BUILD_NAME to BUILD_ARGS

### DIFF
--- a/legacy/build-deploy-docker-compose.sh
+++ b/legacy/build-deploy-docker-compose.sh
@@ -628,10 +628,8 @@ if [[ "$BUILD_TYPE" == "pullrequest"  ||  "$BUILD_TYPE" == "branch" ]]; then
     BUILD_ARGS+=(--build-arg LAGOON_PR_NUMBER="${PR_NUMBER}")
   fi
 
-  # Add in random number as per https://github.com/uselagoon/lagoon/issues/2246
-
-  RANDOM_BUILD_ARG=$(echo $RANDOM | md5sum -z | head -c 32)
-  BUILD_ARGS+=(--build-arg LAGOON_RANDOMIZER="${RANDOM_BUILD_ARG}")
+  # Add in random data as per https://github.com/uselagoon/lagoon/issues/2246
+  BUILD_ARGS+=(--build-arg LAGOON_BUILD_NAME="${LAGOON_BUILD_NAME}")
 
   for IMAGE_NAME in "${IMAGES[@]}"
   do

--- a/legacy/build-deploy-docker-compose.sh
+++ b/legacy/build-deploy-docker-compose.sh
@@ -628,6 +628,11 @@ if [[ "$BUILD_TYPE" == "pullrequest"  ||  "$BUILD_TYPE" == "branch" ]]; then
     BUILD_ARGS+=(--build-arg LAGOON_PR_NUMBER="${PR_NUMBER}")
   fi
 
+  # Add in random number as per https://github.com/uselagoon/lagoon/issues/2246
+
+  RANDOM_BUILD_ARG=$(echo $RANDOM | md5sum -z | head -c 32)
+  BUILD_ARGS+=(--build-arg LAGOON_RANDOMIZER="${RANDOM_BUILD_ARG}")
+
   for IMAGE_NAME in "${IMAGES[@]}"
   do
 


### PR DESCRIPTION
https://github.com/uselagoon/lagoon/issues/2246 raised the question of adding randomization in a build arg in order to break caching. This PR (at the suggestion of @tobybellwood ) injects the build pod's hostname (which is unique) as the variable `LAGOON_BUILD_NAME`.