### PR TITLE
chore: support consuming deployer-token from service account

### DIFF
--- a/internal/lagoon/tasks.go
+++ b/internal/lagoon/tasks.go
@@ -80,13 +80,14 @@ func getConfig() (*rest.Config, error) {
 	*kubeconfig = helpers.GetEnv("KUBECONFIG", "", false)
 
 	if *kubeconfig == "" {
-		//return nil, fmt.Errorf("Unable to find a valid KUBECONFIG")
 		//Fall back on out of cluster
-
 		// read the deployer token.
 		token, err := ioutil.ReadFile("/var/run/secrets/lagoon/deployer/token")
 		if err != nil {
-			return nil, err
+			token, err = ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+			if err != nil {
+				return nil, err
+			}
 		}
 		// generate the rest config for the client.
 		restCfg := &rest.Config{

--- a/legacy/build-deploy.sh
+++ b/legacy/build-deploy.sh
@@ -62,7 +62,14 @@ PRIVATE_DOCKER_HUB_REGISTRY=0
 PRIVATE_EXTERNAL_REGISTRY=0
 
 set +x # reduce noise in build logs
-DEPLOYER_TOKEN=$(cat /var/run/secrets/lagoon/deployer/token)
+if [[ -f "/var/run/secrets/lagoon/deployer/token" ]]; then
+  DEPLOYER_TOKEN=$(cat /var/run/secrets/lagoon/deployer/token)
+else
+  DEPLOYER_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+fi
+if [ -z ${DEPLOYER_TOKEN} ]; then
+  echo "No deployer token found"; exit 1;
+fi
 
 kubectl config set-credentials lagoon/kubernetes.default.svc --token="${DEPLOYER_TOKEN}"
 kubectl config set-cluster kubernetes.default.svc --server=https://kubernetes.default.svc --certificate-authority=/run/secrets/kubernetes.io/serviceaccount/ca.crt


### PR DESCRIPTION
In kubernetes 1.24, service accounts no longer get automatically generated token secrets. It is possible to generate long lived tokens, but using the TokenRequest API is the recommended way forward.

The remote-controller will now use the serviceaccount on all pods started by it, which uses volume projection to mount the token into the pod automatically.

The default will be to try the existing token location, but if one has been provided the service account, it will use this this.