### PR TITLE
fix: cronjob templates

### DIFF
--- a/legacy/helmcharts/basic-persistent/templates/cronjob.yaml
+++ b/legacy/helmcharts/basic-persistent/templates/cronjob.yaml
@@ -75,15 +75,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/basic/templates/cronjob.yaml
+++ b/legacy/helmcharts/basic/templates/cronjob.yaml
@@ -68,15 +68,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/cli-persistent/templates/cronjob.yaml
+++ b/legacy/helmcharts/cli-persistent/templates/cronjob.yaml
@@ -82,15 +82,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/cli/templates/cronjob.yaml
+++ b/legacy/helmcharts/cli/templates/cronjob.yaml
@@ -77,15 +77,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/elasticsearch/templates/cronjob.yaml
+++ b/legacy/helmcharts/elasticsearch/templates/cronjob.yaml
@@ -68,15 +68,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/kibana/templates/cronjob.yaml
+++ b/legacy/helmcharts/kibana/templates/cronjob.yaml
@@ -77,11 +77,11 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           tolerations:
             - effect: NoSchedule

--- a/legacy/helmcharts/logstash/templates/cronjob.yaml
+++ b/legacy/helmcharts/logstash/templates/cronjob.yaml
@@ -68,15 +68,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/mariadb-single/templates/cronjob.yaml
+++ b/legacy/helmcharts/mariadb-single/templates/cronjob.yaml
@@ -75,15 +75,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/mongodb-single/templates/cronjob.yaml
+++ b/legacy/helmcharts/mongodb-single/templates/cronjob.yaml
@@ -75,15 +75,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/nginx-php-persistent/templates/cronjob.yaml
+++ b/legacy/helmcharts/nginx-php-persistent/templates/cronjob.yaml
@@ -82,15 +82,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/nginx-php/templates/cronjob.yaml
+++ b/legacy/helmcharts/nginx-php/templates/cronjob.yaml
@@ -77,15 +77,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/nginx/templates/cronjob.yaml
+++ b/legacy/helmcharts/nginx/templates/cronjob.yaml
@@ -77,15 +77,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/node-persistent/templates/cronjob.yaml
+++ b/legacy/helmcharts/node-persistent/templates/cronjob.yaml
@@ -82,15 +82,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/node/templates/cronjob.yaml
+++ b/legacy/helmcharts/node/templates/cronjob.yaml
@@ -68,15 +68,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/opensearch/templates/cronjob.yaml
+++ b/legacy/helmcharts/opensearch/templates/cronjob.yaml
@@ -68,15 +68,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/postgres-single/templates/cronjob.yaml
+++ b/legacy/helmcharts/postgres-single/templates/cronjob.yaml
@@ -75,15 +75,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/python-persistent/templates/cronjob.yaml
+++ b/legacy/helmcharts/python-persistent/templates/cronjob.yaml
@@ -82,15 +82,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/python/templates/cronjob.yaml
+++ b/legacy/helmcharts/python/templates/cronjob.yaml
@@ -69,15 +69,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/rabbitmq/templates/cronjob.yaml
+++ b/legacy/helmcharts/rabbitmq/templates/cronjob.yaml
@@ -68,15 +68,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/redis-persistent/templates/cronjob.yaml
+++ b/legacy/helmcharts/redis-persistent/templates/cronjob.yaml
@@ -75,15 +75,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/redis/templates/cronjob.yaml
+++ b/legacy/helmcharts/redis/templates/cronjob.yaml
@@ -68,15 +68,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/solr/templates/cronjob.yaml
+++ b/legacy/helmcharts/solr/templates/cronjob.yaml
@@ -68,15 +68,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/varnish-persistent/templates/cronjob.yaml
+++ b/legacy/helmcharts/varnish-persistent/templates/cronjob.yaml
@@ -75,15 +75,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/varnish/templates/cronjob.yaml
+++ b/legacy/helmcharts/varnish/templates/cronjob.yaml
@@ -68,15 +68,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/worker-persistent/templates/cronjob.yaml
+++ b/legacy/helmcharts/worker-persistent/templates/cronjob.yaml
@@ -82,15 +82,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:

--- a/legacy/helmcharts/worker/templates/cronjob.yaml
+++ b/legacy/helmcharts/worker/templates/cronjob.yaml
@@ -77,15 +77,15 @@ spec:
           restartPolicy: Never
           {{- with $.Values.cronjobNodeSelector }}
           nodeSelector:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with $.Values.cronjobAffinity }}
           affinity:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.cronjobTolerations }}
           tolerations:
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           dnsConfig:
             options:


### PR DESCRIPTION
There is an issue with cronjob templates where filling out the affinity, nodeselector, or tolerations will fail. This corrects the templating issues.