### PR TITLE
fix: replace special chars with underscore for postgres-single backups

### DIFF
--- a/legacy/helmcharts/postgres-single/templates/deployment.yaml
+++ b/legacy/helmcharts/postgres-single/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{- end }}
       annotations:
         {{- include "postgres-single.annotations" . | nindent 8 }}
-        k8up.syn.tools/backupcommand: /bin/sh -c "PGPASSWORD=${{ upper .Release.Name }}_PASSWORD pg_dump --host=localhost --port=${{ upper .Release.Name }}_SERVICE_PORT --dbname=${{ upper .Release.Name }}_DB --username=${{ upper .Release.Name }}_USER --format=t -w"
+        k8up.syn.tools/backupcommand: /bin/sh -c "PGPASSWORD=${{ regexReplaceAll "\\W+" .Release.Name "_" | upper }}}_PASSWORD pg_dump --host=localhost --port=${{ regexReplaceAll "\\W+" .Release.Name "_" | upper }}}_SERVICE_PORT --dbname=${{ regexReplaceAll "\\W+" .Release.Name "_" | upper }}}_DB --username=${{ regexReplaceAll "\\W+" .Release.Name "_" | upper }}}_USER --format=t -w"
         k8up.syn.tools/file-extension: .{{ include "postgres-single.fullname" . }}.tar
         lagoon.sh/configMapSha: {{ .Values.configMapSha | quote }}
     spec:

--- a/legacy/helmcharts/postgres-single/templates/deployment.yaml
+++ b/legacy/helmcharts/postgres-single/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{- end }}
       annotations:
         {{- include "postgres-single.annotations" . | nindent 8 }}
-        k8up.syn.tools/backupcommand: /bin/sh -c "PGPASSWORD=${{ regexReplaceAll "\\W+" .Release.Name "_" | upper }}}_PASSWORD pg_dump --host=localhost --port=${{ regexReplaceAll "\\W+" .Release.Name "_" | upper }}}_SERVICE_PORT --dbname=${{ regexReplaceAll "\\W+" .Release.Name "_" | upper }}}_DB --username=${{ regexReplaceAll "\\W+" .Release.Name "_" | upper }}}_USER --format=t -w"
+        k8up.syn.tools/backupcommand: /bin/sh -c "PGPASSWORD=${{ regexReplaceAll "\\W+" .Release.Name "_" | upper }}_PASSWORD pg_dump --host=localhost --port=${{ regexReplaceAll "\\W+" .Release.Name "_" | upper }}_SERVICE_PORT --dbname=${{ regexReplaceAll "\\W+" .Release.Name "_" | upper }}_DB --username=${{ regexReplaceAll "\\W+" .Release.Name "_" | upper }}_USER --format=t -w"
         k8up.syn.tools/file-extension: .{{ include "postgres-single.fullname" . }}.tar
         lagoon.sh/configMapSha: {{ .Values.configMapSha | quote }}
     spec:


### PR DESCRIPTION
[This playground shows the fix](https://repeatit.io/#/share/eyJ0ZW1wbGF0ZSI6Int7IHJlZ2V4UmVwbGFjZUFsbCBcIlxcXFxXK1wiIC5SZWxlYXNlLk5hbWUgXCJfXCIgfCB1cHBlciB9fSIsImlucHV0IjoiUmVsZWFzZTpcbiAgTmFtZTogcG9zdGdyZXMtZGF0YXN0b3JlIiwiY29uZmlnIjp7InRlbXBsYXRlIjoidGV4dCIsImZ1bGxTY3JlZW5IVE1MIjpmYWxzZSwiZnVuY3Rpb25zIjpbInNwcmlnIl0sIm9wdGlvbnMiOlsibGl2ZSJdLCJpbnB1dFR5cGUiOiJ5YW1sIn19)

Running the template command against it (`helm template postgres-datastore legacy/helmcharts/postgres-single/`), it renders correctly: 
```
        k8up.syn.tools/backupcommand: /bin/sh -c "PGPASSWORD=$POSTGRES_DATASTORE_PASSWORD pg_dump --host=localhost --port=$POSTGRES_DATASTORE_SERVICE_PORT --dbname=$POSTGRES_DATASTORE_DB --username=$POSTGRES_DATASTORE_USER --format=t -w"
```
closes #150 