### PR TITLE
open/elasticsearch prebackup podaffinity required

### DIFF
--- a/legacy/helmcharts/elasticsearch/templates/prebackuppod.yaml
+++ b/legacy/helmcharts/elasticsearch/templates/prebackuppod.yaml
@@ -18,16 +18,14 @@ spec:
     spec:
       affinity:
         podAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: lagoon.sh/service
-                      operator: In
-                      values:
-                        - {{ include "elasticsearch.fullname" . }}
-                topologyKey: kubernetes.io/hostname
-              weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: lagoon.sh/service
+                    operator: In
+                    values:
+                      - {{ .Release.Name }}
+              topologyKey: kubernetes.io/hostname
       containers:
         - args:
             - sleep

--- a/legacy/helmcharts/opensearch/templates/prebackuppod.yaml
+++ b/legacy/helmcharts/opensearch/templates/prebackuppod.yaml
@@ -18,16 +18,14 @@ spec:
     spec:
       affinity:
         podAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: lagoon.sh/service
-                      operator: In
-                      values:
-                        - {{ include "opensearch.fullname" . }}
-                topologyKey: kubernetes.io/hostname
-              weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: lagoon.sh/service
+                    operator: In
+                    values:
+                      - {{ .Release.Name }}
+              topologyKey: kubernetes.io/hostname
       containers:
         - args:
             - sleep


### PR DESCRIPTION
Previously it was possible for a prebackup pod to schedule on a different node to the opensearch/elasticsearch RWO PV, which would cause a multi-attach error.

Here, the podAffinity is set to Required (instead of Preferred) and handled more explicitly. If it can't get on the node, it will fail to schedule.