### PR TITLE
feat: bump memory requests for node and php charts

### DIFF
--- a/legacy/helmcharts/nginx-php-persistent/values.yaml
+++ b/legacy/helmcharts/nginx-php-persistent/values.yaml
@@ -54,7 +54,7 @@ resources:
     #   memory: 128Mi
     requests:
       cpu: 10m
-      memory: 10Mi
+      memory: 100Mi
 
 nodeSelector: {}
 

--- a/legacy/helmcharts/nginx-php/values.yaml
+++ b/legacy/helmcharts/nginx-php/values.yaml
@@ -51,7 +51,7 @@ resources:
     #   memory: 128Mi
     requests:
       cpu: 10m
-      memory: 10Mi
+      memory: 100Mi
 
 nodeSelector: {}
 

--- a/legacy/helmcharts/node-persistent/values.yaml
+++ b/legacy/helmcharts/node-persistent/values.yaml
@@ -44,7 +44,7 @@ resources:
   #   memory: 128Mi
   requests:
     cpu: 10m
-    memory: 10Mi
+    memory: 100Mi
 
 nodeSelector: {}
 

--- a/legacy/helmcharts/node/values.yaml
+++ b/legacy/helmcharts/node/values.yaml
@@ -41,7 +41,7 @@ resources:
   #   memory: 128Mi
   requests:
     cpu: 10m
-    memory: 10Mi
+    memory: 100Mi
 
 nodeSelector: {}
 


### PR DESCRIPTION
Empirical evidence suggests that the median memory usage for php and node is much closer to 100Mi than 10Mi.