### PR TITLE
Error msg for builds without a Lagoon type

### DIFF
--- a/internal/generator/services.go
+++ b/internal/generator/services.go
@@ -90,9 +90,8 @@ func composeToServiceValues(
 		lagoonType = lagoon.CheckServiceLagoonLabel(composeServiceValues.Labels, "lagoon.type")
 	}
 	if lagoonType == "" {
-		return ServiceValues{}, fmt.Errorf("No Lagoon type has been set for service %s. If a Lagoon type is not required for this service, please set the Lagoon type to 'none'", composeService)
-	}
-	if lagoonType != "" {
+		return ServiceValues{}, fmt.Errorf("No lagoon.type has been set for service %s. If a Lagoon service is not required, please set the lagoon.type to 'none' for this service in docker-compose.yaml. See the Lagoon documentation for supported service types.", composeService)
+	} else {
 		// if the lagoontype is populated, even none is valid as there may be a servicetype override in an environment variable
 		autogenEnabled := true
 		autogenTLSAcmeEnabled := true

--- a/internal/generator/services.go
+++ b/internal/generator/services.go
@@ -89,6 +89,9 @@ func composeToServiceValues(
 	if composeServiceValues.Labels != nil {
 		lagoonType = lagoon.CheckServiceLagoonLabel(composeServiceValues.Labels, "lagoon.type")
 	}
+	if lagoonType == "" {
+		return ServiceValues{}, fmt.Errorf("No Lagoon type has been set for service %s. If a Lagoon type is not required for this service, please set the Lagoon type to 'none'", composeService)
+	}
 	if lagoonType != "" {
 		// if the lagoontype is populated, even none is valid as there may be a servicetype override in an environment variable
 		autogenEnabled := true

--- a/internal/generator/services_test.go
+++ b/internal/generator/services_test.go
@@ -278,7 +278,8 @@ func Test_composeToServiceValues(t *testing.T) {
 				composeService:       "nginx",
 				composeServiceValues: composetypes.ServiceConfig{},
 			},
-			want: ServiceValues{},
+			want:    ServiceValues{},
+			wantErr: true,
 		},
 		{
 			name: "test9 - type none, no service",


### PR DESCRIPTION
The current error response for builds with no Lagoon type set is quite generic - e.g. `Rollout for ${SERVICE_NAME} failed, tried to gather some startup logs of the containers, but unfortunately there were none created, sorry.`

This provides a more verbose error message when no Lagoon type is set.

![image](https://user-images.githubusercontent.com/40746380/210033363-3b4488ab-7e24-4be1-8632-4f020df0d7b8.png)
