### PR TITLE
revert openssh 9.1_p1-r2 pinning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ ENV KUBECTL_VERSION=v1.20.4 \
 
 RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing aufs-util \
     && apk add --update openssl curl jq parallel \
-    && apk add --no-cache bash git openssh-client-common=9.1_p1-r2 openssh=9.1_p1-r2 py-pip skopeo \
+    && apk add --no-cache bash git openssh py-pip skopeo \
     && git config --global user.email "lagoon@lagoon.io" && git config --global user.name lagoon \
     && pip install shyaml yq \
     && curl -Lo /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,8 +70,8 @@ ENV KUBECTL_VERSION=v1.20.4 \
     HELM_SHA256=01b317c506f8b6ad60b11b1dc3f093276bb703281cb1ae01132752253ec706a2
 
 RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing aufs-util \
-    && apk add --update openssl curl jq parallel \
-    && apk add --no-cache bash git openssh py-pip skopeo \
+    && apk upgrade --no-cache openssh openssh-keygen openssh-client-common openssh-client-default \
+    && apk add --no-cache openssl curl jq parallel bash git py-pip skopeo \
     && git config --global user.email "lagoon@lagoon.io" && git config --global user.name lagoon \
     && pip install shyaml yq \
     && curl -Lo /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl \


### PR DESCRIPTION
in #164 we needed to pin the OpenSSH version to avoid an Alpine package resolution error - once this PR passes tests, we should merge it to remove that pin.

The conflict is caused by the upstream docker/20.10.22 image already having an older version of some OpenSSH libraries installed. These libraries have been updated in the Alpine package registry. Our attempt to install a newer version of the parent OpenSSH package, therefore, causes conflicts.

This PR, therefore, installs and upgrades all the OpenSSH libraries and packages in a single step.