### PR TITLE
Fix: Cronjob templates

### DIFF
--- a/legacy/helmcharts/basic-persistent/templates/deployment.yaml
+++ b/legacy/helmcharts/basic-persistent/templates/deployment.yaml
@@ -65,8 +65,7 @@ spec:
             - name: LAGOON_GIT_SHA
               value: {{ .Values.gitSha | quote }}
             - name: CRONJOBS
-              value: |
-                {{- toYaml .Values.inPodCronjobs | nindent 16 }}
+              value: {{ .Values.inPodCronjobs | toYaml | indent 14 | trim }}
           envFrom:
             - configMapRef:
                 name: lagoon-env

--- a/legacy/helmcharts/basic-persistent/values.yaml
+++ b/legacy/helmcharts/basic-persistent/values.yaml
@@ -60,6 +60,8 @@ cronjobAffinity: {}
 
 inPodCronjobs: ""
 
+nativeCronjobs: {}
+
 configMapSha: ""
 
 useSpot: false

--- a/legacy/helmcharts/basic/templates/deployment.yaml
+++ b/legacy/helmcharts/basic/templates/deployment.yaml
@@ -64,8 +64,7 @@ spec:
             - name: LAGOON_GIT_SHA
               value: {{ .Values.gitSha | quote }}
             - name: CRONJOBS
-              value: |
-                {{- toYaml .Values.inPodCronjobs | nindent 16 }}
+              value: {{ .Values.inPodCronjobs | toYaml | indent 14 | trim }}
           envFrom:
             - configMapRef:
                 name: lagoon-env

--- a/legacy/helmcharts/basic/values.yaml
+++ b/legacy/helmcharts/basic/values.yaml
@@ -57,6 +57,8 @@ cronjobAffinity: {}
 
 inPodCronjobs: ""
 
+nativeCronjobs: {}
+
 configMapSha: ""
 
 useSpot: false

--- a/legacy/helmcharts/cli-persistent/templates/deployment.yaml
+++ b/legacy/helmcharts/cli-persistent/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
             - name: CRONJOBS
-              value: {{ .Values.inPodCronjobs | quote }}
+              value: {{ .Values.inPodCronjobs | toYaml | indent 14 | trim }}
             ## LAGOON_GIT_SHA is injected directly and not loaded via `lagoon-env` config
             ## This will cause the pod to redeploy on every deployment, even the files have not changed
             - name: LAGOON_GIT_SHA

--- a/legacy/helmcharts/cli-persistent/values.yaml
+++ b/legacy/helmcharts/cli-persistent/values.yaml
@@ -52,7 +52,7 @@ cronjobAffinity: {}
 
 inPodCronjobs: ""
 
-nativeinPodCronjobs: ""
+nativeCronjobs: {}
 
 configMapSha: ""
 

--- a/legacy/helmcharts/cli/templates/deployment.yaml
+++ b/legacy/helmcharts/cli/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
             - name: CRONJOBS
-              value: {{ .Values.inPodCronjobs | quote }}
+              value: {{ .Values.inPodCronjobs | toYaml | indent 14 | trim }}
             ## LAGOON_GIT_SHA is injected directly and not loaded via `lagoon-env` config
             ## This will cause the pod to redeploy on every deployment, even the files have not changed
             - name: LAGOON_GIT_SHA

--- a/legacy/helmcharts/cli/values.yaml
+++ b/legacy/helmcharts/cli/values.yaml
@@ -50,7 +50,7 @@ cronjobAffinity: {}
 
 inPodCronjobs: ""
 
-nativeinPodCronjobs: ""
+nativeCronjobs: {}
 
 configMapSha: ""
 

--- a/legacy/helmcharts/elasticsearch/templates/deployment.yaml
+++ b/legacy/helmcharts/elasticsearch/templates/deployment.yaml
@@ -86,7 +86,7 @@ spec:
                 name: lagoon-env
           env:
             - name: CRONJOBS
-              value: {{ .Values.inPodCronjobs | quote }}
+              value: {{ .Values.inPodCronjobs | toYaml | indent 14 | trim }}
           volumeMounts:
             - name: {{ include "elasticsearch.persistentStorageName" . }}
               mountPath: {{ .Values.persistentStorage.path | quote }}

--- a/legacy/helmcharts/elasticsearch/values.yaml
+++ b/legacy/helmcharts/elasticsearch/values.yaml
@@ -54,6 +54,8 @@ cronjobAffinity: {}
 
 inPodCronjobs: ""
 
+nativeCronjobs: {}
+
 configMapSha: ""
 
 useSpot: false

--- a/legacy/helmcharts/kibana/templates/deployment.yaml
+++ b/legacy/helmcharts/kibana/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
             - name: CRONJOBS
-              value: {{ .Values.cronjobs | quote }}
+              value: {{ .Values.inPodCronjobs | toYaml | indent 14 | trim }}
             - name: LAGOON_GIT_SHA
               value: {{ .Values.gitSha | quote }}
           envFrom:

--- a/legacy/helmcharts/kibana/values.yaml
+++ b/legacy/helmcharts/kibana/values.yaml
@@ -75,7 +75,7 @@ affinity: {}
 
 cronjobAffinity: {}
 
-cronjobs: ""
+inPodCronjobs: ""
 
 nativeCronjobs: {}
 

--- a/legacy/helmcharts/kibana/values.yaml
+++ b/legacy/helmcharts/kibana/values.yaml
@@ -77,6 +77,8 @@ cronjobAffinity: {}
 
 cronjobs: ""
 
+nativeCronjobs: {}
+
 tls_acme: false
 routesAutogenerateInsecure: Allow
 

--- a/legacy/helmcharts/logstash/values.yaml
+++ b/legacy/helmcharts/logstash/values.yaml
@@ -70,6 +70,8 @@ cronjobAffinity: {}
 
 inPodCronjobs: ""
 
+nativeCronjobs: {}
+
 configMapSha: ""
 
 useSpot: false

--- a/legacy/helmcharts/mariadb-single/templates/deployment.yaml
+++ b/legacy/helmcharts/mariadb-single/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
             - name: CRONJOBS
-              value: {{ .Values.inPodCronjobs | quote }}
+              value: {{ .Values.inPodCronjobs | toYaml | indent 14 | trim }}
             - name: LAGOON_GIT_SHA
               value: {{ .Values.gitSha | quote }}
           envFrom:

--- a/legacy/helmcharts/mariadb-single/values.yaml
+++ b/legacy/helmcharts/mariadb-single/values.yaml
@@ -75,6 +75,8 @@ cronjobAffinity: {}
 
 inPodCronjobs: ""
 
+nativeCronjobs: {}
+
 tls_acme: false
 routesAutogenerateInsecure: Allow
 

--- a/legacy/helmcharts/mongodb-single/templates/deployment.yaml
+++ b/legacy/helmcharts/mongodb-single/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
             - name: CRONJOBS
-              value: {{ .Values.inPodCronjobs | quote }}
+              value: {{ .Values.inPodCronjobs | toYaml | indent 14 | trim }}
             - name: LAGOON_GIT_SHA
               value: {{ .Values.gitSha | quote }}
           envFrom:

--- a/legacy/helmcharts/mongodb-single/values.yaml
+++ b/legacy/helmcharts/mongodb-single/values.yaml
@@ -75,6 +75,8 @@ cronjobAffinity: {}
 
 inPodCronjobs: ""
 
+nativeCronjobs: {}
+
 tls_acme: false
 routesAutogenerateInsecure: Allow
 

--- a/legacy/helmcharts/nginx-php-persistent/templates/deployment.yaml
+++ b/legacy/helmcharts/nginx-php-persistent/templates/deployment.yaml
@@ -98,7 +98,7 @@ spec:
             - name: NGINX_FASTCGI_PASS
               value: '127.0.0.1'
             - name: CRONJOBS
-              value: {{ .Values.inPodCronjobs | quote }}
+              value: {{ .Values.inPodCronjobs | toYaml | indent 14 | trim }}
           envFrom:
             - configMapRef:
                 name: lagoon-env

--- a/legacy/helmcharts/nginx-php-persistent/values.yaml
+++ b/legacy/helmcharts/nginx-php-persistent/values.yaml
@@ -70,6 +70,8 @@ cronjobAffinity: {}
 
 inPodCronjobs: ""
 
+nativeCronjobs: {}
+
 configMapSha: ""
 
 useSpot: false

--- a/legacy/helmcharts/nginx-php/templates/deployment.yaml
+++ b/legacy/helmcharts/nginx-php/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
             - name: NGINX_FASTCGI_PASS
               value: '127.0.0.1'
             - name: CRONJOBS
-              value: {{ .Values.inPodCronjobs | quote }}
+              value: {{ .Values.inPodCronjobs | toYaml | indent 14 | trim }}
           envFrom:
             - configMapRef:
                 name: lagoon-env

--- a/legacy/helmcharts/nginx-php/values.yaml
+++ b/legacy/helmcharts/nginx-php/values.yaml
@@ -67,6 +67,8 @@ cronjobAffinity: {}
 
 inPodCronjobs: ""
 
+nativeCronjobs: {}
+
 configMapSha: ""
 
 useSpot: false

--- a/legacy/helmcharts/nginx/templates/deployment.yaml
+++ b/legacy/helmcharts/nginx/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
             - name: LAGOON_GIT_SHA
               value: {{ .Values.gitSha | quote }}
             - name: CRONJOBS
-              value: {{ .Values.inPodCronjobs | quote }}
+              value: {{ .Values.inPodCronjobs | toYaml | indent 14 | trim }}
           envFrom:
             - configMapRef:
                 name: lagoon-env

--- a/legacy/helmcharts/nginx/values.yaml
+++ b/legacy/helmcharts/nginx/values.yaml
@@ -77,6 +77,8 @@ cronjobAffinity: {}
 
 inPodCronjobs: ""
 
+nativeCronjobs: {}
+
 tls_acme: false
 routesAutogenerateInsecure: Allow
 

--- a/legacy/helmcharts/node-persistent/templates/deployment.yaml
+++ b/legacy/helmcharts/node-persistent/templates/deployment.yaml
@@ -65,8 +65,7 @@ spec:
             - name: LAGOON_GIT_SHA
               value: {{ .Values.gitSha | quote }}
             - name: CRONJOBS
-              value: |
-                {{- toYaml .Values.inPodCronjobs | nindent 16 }}
+              value: {{ .Values.inPodCronjobs | toYaml | indent 14 | trim }}
           envFrom:
             - configMapRef:
                 name: lagoon-env

--- a/legacy/helmcharts/node-persistent/values.yaml
+++ b/legacy/helmcharts/node-persistent/values.yaml
@@ -60,6 +60,8 @@ cronjobAffinity: {}
 
 inPodCronjobs: ""
 
+nativeCronjobs: {}
+
 configMapSha: ""
 
 useSpot: false

--- a/legacy/helmcharts/node/templates/deployment.yaml
+++ b/legacy/helmcharts/node/templates/deployment.yaml
@@ -64,8 +64,7 @@ spec:
             - name: LAGOON_GIT_SHA
               value: {{ .Values.gitSha | quote }}
             - name: CRONJOBS
-              value: |
-                {{- toYaml .Values.inPodCronjobs | nindent 16 }}
+              value: {{ .Values.inPodCronjobs | toYaml | indent 14 | trim }}
           envFrom:
             - configMapRef:
                 name: lagoon-env

--- a/legacy/helmcharts/node/values.yaml
+++ b/legacy/helmcharts/node/values.yaml
@@ -57,6 +57,8 @@ cronjobAffinity: {}
 
 inPodCronjobs: ""
 
+nativeCronjobs: {}
+
 configMapSha: ""
 
 useSpot: false

--- a/legacy/helmcharts/opensearch/templates/deployment.yaml
+++ b/legacy/helmcharts/opensearch/templates/deployment.yaml
@@ -88,7 +88,7 @@ spec:
                 name: lagoon-env
           env:
             - name: CRONJOBS
-              value: {{ .Values.inPodCronjobs | quote }}
+              value: {{ .Values.inPodCronjobs | toYaml | indent 14 | trim }}
           volumeMounts:
             - name: {{ include "opensearch.persistentStorageName" . }}
               mountPath: {{ .Values.persistentStorage.path | quote }}

--- a/legacy/helmcharts/opensearch/values.yaml
+++ b/legacy/helmcharts/opensearch/values.yaml
@@ -54,6 +54,8 @@ cronjobAffinity: {}
 
 inPodCronjobs: ""
 
+nativeCronjobs: {}
+
 configMapSha: ""
 
 useSpot: false
@@ -63,4 +65,3 @@ cronjobUseSpot: false
 dynamicSecretMounts: []
 
 dynamicSecretVolumes: []
-

--- a/legacy/helmcharts/postgres-single/templates/deployment.yaml
+++ b/legacy/helmcharts/postgres-single/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
             - name: CRONJOBS
-              value: {{ .Values.inPodCronjobs | quote }}
+              value: {{ .Values.inPodCronjobs | toYaml | indent 14 | trim }}
             - name: LAGOON_GIT_SHA
               value: {{ .Values.gitSha | quote }}
           envFrom:

--- a/legacy/helmcharts/postgres-single/values.yaml
+++ b/legacy/helmcharts/postgres-single/values.yaml
@@ -75,6 +75,8 @@ cronjobAffinity: {}
 
 inPodCronjobs: ""
 
+nativeCronjobs: {}
+
 tls_acme: false
 routesAutogenerateInsecure: Allow
 

--- a/legacy/helmcharts/python-persistent/templates/deployment.yaml
+++ b/legacy/helmcharts/python-persistent/templates/deployment.yaml
@@ -66,8 +66,7 @@ spec:
             - name: LAGOON_GIT_SHA
               value: {{ .Values.gitSha | quote }}
             - name: CRONJOBS
-              value: |
-                {{- toYaml .Values.inPodCronjobs | nindent 16 }}
+              value: {{ .Values.inPodCronjobs | toYaml | indent 14 | trim }}
           envFrom:
             - configMapRef:
                 name: lagoon-env

--- a/legacy/helmcharts/python-persistent/values.yaml
+++ b/legacy/helmcharts/python-persistent/values.yaml
@@ -60,6 +60,8 @@ cronjobAffinity: {}
 
 inPodCronjobs: ""
 
+nativeCronjobs: {}
+
 configMapSha: ""
 
 useSpot: false

--- a/legacy/helmcharts/python/templates/deployment.yaml
+++ b/legacy/helmcharts/python/templates/deployment.yaml
@@ -63,8 +63,7 @@ spec:
             - name: LAGOON_GIT_SHA
               value: {{ .Values.gitSha | quote }}
             - name: CRONJOBS
-              value: |
-                {{- toYaml .Values.inPodCronjobs | nindent 16 }}
+              value: {{ .Values.inPodCronjobs | toYaml | indent 14 | trim }}
           envFrom:
             - configMapRef:
                 name: lagoon-env

--- a/legacy/helmcharts/python/values.yaml
+++ b/legacy/helmcharts/python/values.yaml
@@ -57,6 +57,8 @@ cronjobAffinity: {}
 
 inPodCronjobs: ""
 
+nativeCronjobs: {}
+
 configMapSha: ""
 
 useSpot: false

--- a/legacy/helmcharts/rabbitmq/templates/deployment.yaml
+++ b/legacy/helmcharts/rabbitmq/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
                 name: lagoon-env
           env:
             - name: CRONJOBS
-              value: {{ .Values.inPodCronjobs | quote }}
+              value: {{ .Values.inPodCronjobs | toYaml | indent 14 | trim }}
             - name: RABBITMQ_NODENAME
               value: rabbitmq@localhost
           volumeMounts:

--- a/legacy/helmcharts/rabbitmq/values.yaml
+++ b/legacy/helmcharts/rabbitmq/values.yaml
@@ -54,6 +54,8 @@ cronjobAffinity: {}
 
 inPodCronjobs: ""
 
+nativeCronjobs: {}
+
 configMapSha: ""
 
 useSpot: false

--- a/legacy/helmcharts/redis-persistent/templates/deployment.yaml
+++ b/legacy/helmcharts/redis-persistent/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             - name: LAGOON_GIT_SHA
               value: {{ .Values.gitSha | quote }}
             - name: CRONJOBS
-              value: {{ .Values.inPodCronjobs | quote }}
+              value: {{ .Values.inPodCronjobs | toYaml | indent 14 | trim }}
           envFrom:
             - configMapRef:
                 name: lagoon-env

--- a/legacy/helmcharts/redis-persistent/values.yaml
+++ b/legacy/helmcharts/redis-persistent/values.yaml
@@ -75,6 +75,8 @@ cronjobAffinity: {}
 
 inPodCronjobs: ""
 
+nativeCronjobs: {}
+
 configMapSha: ""
 
 useSpot: false

--- a/legacy/helmcharts/redis/templates/deployment.yaml
+++ b/legacy/helmcharts/redis/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
             - name: CRONJOBS
-              value: {{ .Values.inPodCronjobs | quote }}
+              value: {{ .Values.inPodCronjobs | toYaml | indent 14 | trim }}
             - name: LAGOON_GIT_SHA
               value: {{ .Values.gitSha | quote }}
           envFrom:

--- a/legacy/helmcharts/redis/values.yaml
+++ b/legacy/helmcharts/redis/values.yaml
@@ -71,6 +71,8 @@ cronjobAffinity: {}
 
 inPodCronjobs: ""
 
+nativeCronjobs: {}
+
 configMapSha: ""
 
 useSpot: false

--- a/legacy/helmcharts/solr/templates/deployment.yaml
+++ b/legacy/helmcharts/solr/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
                 name: lagoon-env
           env:
             - name: CRONJOBS
-              value: {{ .Values.inPodCronjobs | quote }}
+              value: {{ .Values.inPodCronjobs | toYaml | indent 14 | trim }}
           volumeMounts:
             - name: {{ include "solr.persistentStorageName" . }}
               mountPath: {{ .Values.persistentStorage.path | quote }}

--- a/legacy/helmcharts/solr/values.yaml
+++ b/legacy/helmcharts/solr/values.yaml
@@ -54,6 +54,8 @@ cronjobAffinity: {}
 
 inPodCronjobs: ""
 
+nativeCronjobs: {}
+
 configMapSha: ""
 
 useSpot: false

--- a/legacy/helmcharts/varnish-persistent/values.yaml
+++ b/legacy/helmcharts/varnish-persistent/values.yaml
@@ -79,6 +79,8 @@ affinity: {}
 
 cronjobAffinity: {}
 
+nativeCronjobs: {}
+
 configMapSha: ""
 
 useSpot: false

--- a/legacy/helmcharts/varnish/values.yaml
+++ b/legacy/helmcharts/varnish/values.yaml
@@ -75,6 +75,8 @@ affinity: {}
 
 cronjobAffinity: {}
 
+nativeCronjobs: {}
+
 configMapSha: ""
 
 useSpot: false

--- a/legacy/helmcharts/worker-persistent/templates/deployment.yaml
+++ b/legacy/helmcharts/worker-persistent/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
             - name: CRONJOBS
-              value: {{ .Values.inPodCronjobs | quote }}
+              value: {{ .Values.inPodCronjobs | toYaml | indent 14 | trim }}
             ## LAGOON_GIT_SHA is injected directly and not loaded via `lagoon-env` config
             ## This will cause the pod to redeploy on every deployment, even the files have not changed
             - name: LAGOON_GIT_SHA

--- a/legacy/helmcharts/worker-persistent/values.yaml
+++ b/legacy/helmcharts/worker-persistent/values.yaml
@@ -52,7 +52,7 @@ cronjobAffinity: {}
 
 inPodCronjobs: ""
 
-nativeinPodCronjobs: ""
+nativeCronjobs: {}
 
 configMapSha: ""
 

--- a/legacy/helmcharts/worker/templates/deployment.yaml
+++ b/legacy/helmcharts/worker/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
             - name: CRONJOBS
-              value: {{ .Values.inPodCronjobs | quote }}
+              value: {{ .Values.inPodCronjobs | toYaml | indent 14 | trim }}
             ## LAGOON_GIT_SHA is injected directly and not loaded via `lagoon-env` config
             ## This will cause the pod to redeploy on every deployment, even the files have not changed
             - name: LAGOON_GIT_SHA

--- a/legacy/helmcharts/worker/values.yaml
+++ b/legacy/helmcharts/worker/values.yaml
@@ -50,7 +50,7 @@ cronjobAffinity: {}
 
 inPodCronjobs: ""
 
-nativeinPodCronjobs: ""
+nativeCronjobs: {}
 
 configMapSha: ""
 


### PR DESCRIPTION
This PR has three fixes:

1. `inPodCronjobs` for `kibana` service had an incorrect values variable and were not working
2. Default values files for services didn't include `nativeCronjobs` or they included a misspelling of it
3. Some services used a template directive for `inPodCronjobs` that would trigger the `go-crond` entrypoint in our commons image, even if no cronjobs were defined in `.lagoon.yml`

closes #182 