### PR TITLE
feat: add validation for multiline cron jobs and validate at start of build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,7 @@ ENV IMAGECACHE_REGISTRY=imagecache.amazeeio.cloud
 
 ENV DBAAS_OPERATOR_HTTP=dbaas.lagoon.svc:5000
 
-RUN curl -sSL https://github.com/uselagoon/lagoon-linter/releases/download/v0.7.0/lagoon-linter_0.7.0_linux_amd64.tar.gz \
+RUN curl -sSL https://github.com/uselagoon/lagoon-linter/releases/download/v0.8.0/lagoon-linter_0.8.0_linux_amd64.tar.gz \
     | tar -xz -C /usr/local/bin lagoon-linter
 
 # RUN curl -sSL https://github.com/uselagoon/build-deploy-tool/releases/download/v0.11.0/build-deploy-tool_0.11.0_linux_amd64.tar.gz \

--- a/internal/lagoon/lagoon.go
+++ b/internal/lagoon/lagoon.go
@@ -18,11 +18,18 @@ type ProductionRoutes struct {
 	Standby *Environment `json:"standby"`
 }
 
+// Cronjob represents a Lagoon cronjob.
+type Cronjob struct {
+	Name    string `json:"name"`
+	Command string `json:"command"`
+}
+
 // Environment represents a Lagoon environment.
 type Environment struct {
 	AutogenerateRoutes *bool                `json:"autogenerateRoutes"`
 	Types              map[string]string    `json:"types"`
 	Routes             []map[string][]Route `json:"routes"`
+	Cronjobs           []Cronjob            `json:"cronjobs"`
 }
 
 // Environments .
@@ -80,7 +87,6 @@ type Autogenerate struct {
 	IngressClass      string   `json:"ingressClass"`
 }
 
-//
 func (a *Routes) UnmarshalJSON(data []byte) error {
 	tmpMap := map[string]interface{}{}
 	json.Unmarshal(data, &tmpMap)

--- a/legacy/build-deploy-docker-compose.sh
+++ b/legacy/build-deploy-docker-compose.sh
@@ -187,6 +187,7 @@ if kubectl -n ${NAMESPACE} get configmap docker-compose-yaml &> /dev/null; then
   # create it
   kubectl -n ${NAMESPACE} create configmap docker-compose-yaml --from-file=pre-deploy=${DOCKER_COMPOSE_YAML}
 fi
+
 set +ex
 ##############################################
 ### RUN docker compose config check against the provided docker-compose file
@@ -213,7 +214,36 @@ You can run docker compose config locally to check that your docker-compose file
   exit 1
 fi
 set -ex
-# validate .lagoon.yml
+
+set +ex
+##############################################
+### RUN lagoon-yml validation against the final data which may have overrides
+### from .lagoon.override.yml file or LAGOON_YAML_OVERRIDE environment variable
+##############################################
+lyvOutput=$(bash -c 'build-deploy-tool validate lagoon-yml; exit $?' 2>&1)
+lyvExit=$?
+
+if [ "${lyvExit}" != "0" ]; then
+  currentStepEnd="$(date +"%Y-%m-%d %H:%M:%S")"
+  patchBuildStep "${buildStartTime}" "${previousStepEnd}" "${currentStepEnd}" "${NAMESPACE}" "lagoonYmlValidationError" ".lagoon.yml Validation Error"
+  previousStepEnd=${currentStepEnd}
+  echo "
+##############################################
+Warning!
+There are issues with your .lagoon.yml file that must be fixed.
+Refer to the .lagoon.yml docs for the correct syntax
+https://docs.lagoon.sh/using-lagoon-the-basics/lagoon-yml/
+##############################################
+"
+  echo "${lyvOutput}"
+  echo "
+##############################################"
+  exit 1
+fi
+set -ex
+
+# Validate .lagoon.yml only, no overrides. lagoon-linter still has checks that
+# aren't in build-deploy-tool.
 if ! lagoon-linter; then
 	echo "https://docs.lagoon.sh/lagoon/using-lagoon-the-basics/lagoon-yml#restrictions describes some possible reasons for this build failure."
 	echo "If you require assistance to fix this error, please contact support."

--- a/test-resources/validate-lagoon-yml/cronjobs/lagoon-override-env.yml
+++ b/test-resources/validate-lagoon-yml/cronjobs/lagoon-override-env.yml
@@ -1,0 +1,20 @@
+tasks:
+  pre-rollout:
+    - run:
+        name: envvar pre-rollout task1
+        command: echo "task 1"
+        service: cli
+        weight: -1
+  post-rollout:
+    - run:
+        name: envvar post-rollout task1
+        command: echo "task 1"
+        service: cli
+        shell: bash
+        weight: -1
+    - run:
+        name: envvar post-rollout task2
+        command: echo "task 2"
+        service: cli
+        shell: bash
+        weight: 1

--- a/test-resources/validate-lagoon-yml/cronjobs/lagoon-override.yml
+++ b/test-resources/validate-lagoon-yml/cronjobs/lagoon-override.yml
@@ -1,0 +1,20 @@
+tasks:
+  pre-rollout:
+    - run:
+        name: file pre-rollout task1
+        command: echo "task 1"
+        service: cli
+        weight: -1
+  post-rollout:
+    - run:
+        name: file post-rollout task1
+        command: echo "task 1"
+        service: cli
+        shell: bash
+        weight: -1
+    - run:
+        name: file post-rollout task2
+        command: echo "task 2"
+        service: cli
+        shell: bash
+        weight: 1

--- a/test-resources/validate-lagoon-yml/cronjobs/lagoon.yml
+++ b/test-resources/validate-lagoon-yml/cronjobs/lagoon.yml
@@ -1,0 +1,49 @@
+docker-compose-yaml: docker-compose.yml
+environments:
+    main:
+      cronjobs:
+        - name: block scalar literal stripped
+          command: |-
+            multiline
+            command
+
+        - name: flow scalar plain 2
+          command: singleline command
+      routes:
+        -   nginx:
+            - a.example.com:
+                tls-acme: "true"
+            - b.example.com
+            - c.example.com
+production_routes:
+  active:
+    routes:
+      - nginx:
+          - "active.example.com":
+              tls-acme: "true"
+              insecure: Redirect
+  standby:
+    routes:
+      - nginx:
+          - "standby.example.com":
+              tls-acme: "false"
+              insecure: Redirect
+
+
+tasks:
+  pre-rollout:
+    - run:
+        name: lagoon.yml pre-rollout task1
+        command: echo "task 1"
+        service: cli
+  post-rollout:
+    - run:
+        name: lagoon.yml post-rollout task1
+        command: echo "task 1"
+        service: cli
+        shell: bash
+    - run:
+        name: lagoon.yml post-rollout task2
+        command: echo "task 2"
+        service: cli
+        shell: bash

--- a/test-resources/validate-lagoon-yml/cronjobs/multiline-cronjobs.lagoon.yml
+++ b/test-resources/validate-lagoon-yml/cronjobs/multiline-cronjobs.lagoon.yml
@@ -1,0 +1,53 @@
+# All the possible YAML incantations for introducing a newline into a string.
+# https://yaml-multiline.info/
+environments:
+  main:
+    cronjobs:
+      - name: flow scalar plain
+        command: multiline
+
+          command
+      - name: flow scalar single quoted
+        command: 'multiline
+
+          command'
+      - name: flow scalar double quoted newline
+        command: "multiline
+
+          command"
+      - name: flow scalar double quoted escaped
+        command: "multiline\ncommand"
+      - name: multiline block literal clipped
+        command: |
+          multiline
+          command
+
+      - name: block scalar literal stripped
+        command: |-
+          multiline
+          command
+
+      - name: block scalar literal keep
+        command: |+
+          multiline
+          command
+
+      - name: block scalar folded clipped
+        command: >
+          multiline
+
+          command
+
+      - name: block scalar folded stripped
+        command: >-
+          multiline
+
+          command
+
+      - name: block scalar folded keep
+        command: >+
+          multiline
+
+          command
+
+# dummy comment to keep previous newline

--- a/test-resources/validate-lagoon-yml/cronjobs/singleline-cronjobs.lagoon.yml
+++ b/test-resources/validate-lagoon-yml/cronjobs/singleline-cronjobs.lagoon.yml
@@ -1,0 +1,46 @@
+# Strings that may appear to have newlines but don't.
+environments:
+  main:
+    cronjobs:
+      - name: flow scalar plain 1
+        command: singleline
+          command
+      - name: flow scalar plain 2
+        command: singleline command
+      - name: flow scalar plain 3
+        command: singleline\ncommand
+      - name: flow scalar single quoted 1
+        command: 'singleline
+          command'
+      - name: flow scalar single quoted 2
+        command: 'singleline command'
+      - name: flow scalar single quoted 3
+        command: 'singleline\ncommand'
+      - name: flow scalar double quoted 1
+        command: "singleline
+          command"
+      - name: flow scalar double quoted 2
+        command: "singleline command"
+      - name: flow scalar double quoted 3
+        command: "singleline\
+          command"
+      - name: block scalar literal stripped
+        command: |-
+          singleline command
+
+      - name: block scalar folded clipped 1
+        command: >
+          singleline
+          command
+      - name: block scalar folded clipped 2
+        command: >
+          singleline command
+      - name: block scalar folded stripped 1
+        command: >-
+          singleline
+          command
+      - name: block scalar folded stripped 2
+        command: >-
+          singleline command
+
+# dummy comment to keep previous newline


### PR DESCRIPTION
Part of https://github.com/uselagoon/build-deploy-tool/issues/103

Copies the cronjob validation from [lagoon-linter](https://github.com/uselagoon/lagoon-linter) into the `validate lagoon-yml` command and runs validation at the start of every build.

Updates lagoon-linter to v0.8.0.