### PR TITLE
fix: set HSTS max-age to be 1 year by default

### DIFF
--- a/internal/lagoon/routes.go
+++ b/internal/lagoon/routes.go
@@ -59,7 +59,7 @@ type Route struct {
 	Ingresses map[string]Ingress
 }
 
-var defaultHSTSMaxAge = 3153600
+var defaultHSTSMaxAge = 31536000
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (r *Route) UnmarshalJSON(data []byte) error {

--- a/internal/templating/ingress/templates_ingress_test.go
+++ b/internal/templating/ingress/templates_ingress_test.go
@@ -191,7 +191,7 @@ func TestGenerateKubeTemplate(t *testing.T) {
 					},
 					IngressClass: "nginx",
 					HSTSEnabled:  helpers.BoolPtr(true),
-					HSTSMaxAge:   3153600,
+					HSTSMaxAge:   31536000,
 				},
 				values: generator.BuildValues{
 					Project:         "example-project",
@@ -232,7 +232,7 @@ func TestGenerateKubeTemplate(t *testing.T) {
 					},
 					IngressClass:          "nginx",
 					HSTSEnabled:           helpers.BoolPtr(true),
-					HSTSMaxAge:            3153600,
+					HSTSMaxAge:            31536000,
 					HSTSIncludeSubdomains: helpers.BoolPtr(true),
 					HSTSPreload:           helpers.BoolPtr(true),
 				},

--- a/internal/templating/ingress/test-resources/result-custom-ingress4.yaml
+++ b/internal/templating/ingress/test-resources/result-custom-ingress4.yaml
@@ -11,7 +11,7 @@ metadata:
     lagoon.sh/branch: environment-with-really-really-reall-3fdb
     lagoon.sh/version: v2.x.x
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      more_set_headers "Strict-Transport-Security: max-age=3153600";
+      more_set_headers "Strict-Transport-Security: max-age=31536000";
     nginx.ingress.kubernetes.io/server-snippet: |
       add_header X-Robots-Tag "noindex, nofollow";
     nginx.ingress.kubernetes.io/ssl-redirect: "true"

--- a/internal/templating/ingress/test-resources/result-custom-ingress5.yaml
+++ b/internal/templating/ingress/test-resources/result-custom-ingress5.yaml
@@ -11,7 +11,7 @@ metadata:
     lagoon.sh/branch: environment-with-really-really-reall-3fdb
     lagoon.sh/version: v2.x.x
     nginx.ingress.kubernetes.io/configuration-snippet: |-
-      more_set_headers "Strict-Transport-Security: max-age=3153600;includeSubDomains;preload";
+      more_set_headers "Strict-Transport-Security: max-age=31536000;includeSubDomains;preload";
       more_set_headers "MyCustomHeader: Value";
     nginx.ingress.kubernetes.io/server-snippet: |
       add_header X-Robots-Tag "noindex, nofollow";

--- a/test-resources/identify-ingress/test16/lagoon.yml
+++ b/test-resources/identify-ingress/test16/lagoon.yml
@@ -17,7 +17,6 @@ environments:
               monitoring-path: "/api/v1"
               tls-acme: 'false'
               insecure: Allow
-              hsts: max-age=31536000
   master:
     cronjobs:
       - name: drush cron
@@ -30,7 +29,6 @@ environments:
         - "master.content.example.com":
             tls-acme: 'false'
             insecure: Allow
-            hsts: max-age=31536000
   develop:
     cronjobs:
       - name: drush cron
@@ -43,4 +41,3 @@ environments:
         - "develop.content.example.com":
             tls-acme: 'false'
             insecure: Allow
-            hsts: max-age=31536000

--- a/test-resources/template-autogenerated/test20/lagoon.yml
+++ b/test-resources/template-autogenerated/test20/lagoon.yml
@@ -17,7 +17,6 @@ environments:
               monitoring-path: "/api/v1"
               tls-acme: 'false'
               insecure: Allow
-              hsts: max-age=31536000
   master:
     cronjobs:
       - name: drush cron
@@ -30,7 +29,6 @@ environments:
         - "master.content.example.com":
             tls-acme: 'false'
             insecure: Allow
-            hsts: max-age=31536000
   develop:
     cronjobs:
       - name: drush cron
@@ -43,4 +41,3 @@ environments:
         - "develop.content.example.com":
             tls-acme: 'false'
             insecure: Allow
-            hsts: max-age=31536000

--- a/test-resources/template-ingress/test11/lagoon.yml
+++ b/test-resources/template-ingress/test11/lagoon.yml
@@ -17,7 +17,6 @@ environments:
               monitoring-path: "/api/v1"
               tls-acme: 'false'
               insecure: Allow
-              hsts: max-age=31536000
   master:
     cronjobs:
       - name: drush cron
@@ -30,7 +29,6 @@ environments:
         - "master.content.example.com":
             tls-acme: 'false'
             insecure: Allow
-            hsts: max-age=31536000
   develop:
     cronjobs:
       - name: drush cron
@@ -43,4 +41,3 @@ environments:
         - "develop.content.example.com":
             tls-acme: 'false'
             insecure: Allow
-            hsts: max-age=31536000


### PR DESCRIPTION
Sets HSTS `max-age` to 1 year. Removes deprecated `hsts` from test `.lagoon.yml` files.

Closes #188 