### PR TITLE
fix: enforce only one instance of an in-pod cronjob running at once

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.23.3
 require (
 	dario.cat/mergo v1.0.1
 	github.com/PaesslerAG/gval v1.2.4
+	github.com/alessio/shellescape v1.4.1
 	github.com/amazeeio/dbaas-operator v0.3.0
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
 	github.com/compose-spec/compose-go v1.2.7

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,7 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/amazeeio/dbaas-operator v0.3.0 h1:+yd0RHp+TSAUMUo6o7f5/ReqIEpVJHqoRDzfsibtSzQ=
 github.com/amazeeio/dbaas-operator v0.3.0/go.mod h1:fbZuWO1a4JhEJZLrSdOg/+YEzGL6yZcGpfHiIqn72dc=

--- a/internal/generator/services_test.go
+++ b/internal/generator/services_test.go
@@ -943,7 +943,7 @@ func Test_composeToServiceValues(t *testing.T) {
 						Name:     "My Cronjob2",
 						Service:  "cli",
 						Schedule: "3,8,13,18,23,28,33,38,43,48,53,58 * * * *",
-						Command:  "drush cron",
+						Command:  "flock -n /tmp/cron.lock.f6d199ad6c0075de8176b5c0a14a5d571a473001ced482bc9289182da3d90083 -c 'drush cron'",
 						Timeout:  "4h",
 					},
 				},

--- a/internal/generator/volumes_test.go
+++ b/internal/generator/volumes_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func Test_flagDefaultVolumeCreation(t *testing.T) {
-	type args struct {
-	}
 	tests := []struct {
 		name        string
 		buildValues *BuildValues

--- a/internal/testdata/basic/service-templates/test10-basic-no-native-cronjobs/deployment-node.yaml
+++ b/internal/testdata/basic/service-templates/test10-basic-no-native-cronjobs/deployment-node.yaml
@@ -50,8 +50,8 @@ spec:
           value: abcdefg123456
         - name: CRONJOBS
           value: |
-            3,18,33,48 * * * * drush cron
-            18,48 * * * * drush cron
+            3,18,33,48 * * * * flock -n /tmp/cron.lock.932b8586d96eb88e1574cb8a1223a0b964763c7d0ce90d9aff64d2d92e60fd8d -c 'drush cron'
+            18,48 * * * * flock -n /tmp/cron.lock.f6d199ad6c0075de8176b5c0a14a5d571a473001ced482bc9289182da3d90083 -c 'drush cron'
         - name: SERVICE_NAME
           value: node
         envFrom:

--- a/internal/testdata/basic/service-templates/test11-basic-polysite-cronjobs/deployment-node.yaml
+++ b/internal/testdata/basic/service-templates/test11-basic-polysite-cronjobs/deployment-node.yaml
@@ -50,7 +50,7 @@ spec:
           value: abcdefg123456
         - name: CRONJOBS
           value: |
-            3,18,33,48 0 * * * drush cron
+            3,18,33,48 0 * * * flock -n /tmp/cron.lock.932b8586d96eb88e1574cb8a1223a0b964763c7d0ce90d9aff64d2d92e60fd8d -c 'drush cron'
         - name: SERVICE_NAME
           value: node
         envFrom:

--- a/internal/testdata/complex/service-templates/test2-nginx-php/deployment-cli.yaml
+++ b/internal/testdata/complex/service-templates/test2-nginx-php/deployment-cli.yaml
@@ -50,7 +50,7 @@ spec:
           value: "0000000000000000000000000000000000000000"
         - name: CRONJOBS
           value: |
-            3,18,33,48 * * * * drush cron
+            3,18,33,48 * * * * flock -n /tmp/cron.lock.932b8586d96eb88e1574cb8a1223a0b964763c7d0ce90d9aff64d2d92e60fd8d -c 'drush cron'
         - name: SERVICE_NAME
           value: cli
         envFrom:

--- a/internal/testdata/complex/service-templates/test2b-nginx-php/deployment-cli.yaml
+++ b/internal/testdata/complex/service-templates/test2b-nginx-php/deployment-cli.yaml
@@ -50,7 +50,7 @@ spec:
           value: "0000000000000000000000000000000000000000"
         - name: CRONJOBS
           value: |
-            3,18,33,48 * * * * drush cron
+            3,18,33,48 * * * * flock -n /tmp/cron.lock.932b8586d96eb88e1574cb8a1223a0b964763c7d0ce90d9aff64d2d92e60fd8d -c 'drush cron'
         - name: SERVICE_NAME
           value: cli
         envFrom:

--- a/internal/testdata/complex/service-templates/test2c-nginx-php/deployment-cli.yaml
+++ b/internal/testdata/complex/service-templates/test2c-nginx-php/deployment-cli.yaml
@@ -50,7 +50,7 @@ spec:
           value: "0000000000000000000000000000000000000000"
         - name: CRONJOBS
           value: |
-            3,18,33,48 * * * * drush cron
+            3,18,33,48 * * * * flock -n /tmp/cron.lock.932b8586d96eb88e1574cb8a1223a0b964763c7d0ce90d9aff64d2d92e60fd8d -c 'drush cron'
         - name: SERVICE_NAME
           value: cli
         envFrom:

--- a/internal/testdata/complex/service-templates/test2d-nginx-php/deployment-cli.yaml
+++ b/internal/testdata/complex/service-templates/test2d-nginx-php/deployment-cli.yaml
@@ -50,7 +50,7 @@ spec:
           value: "0000000000000000000000000000000000000000"
         - name: CRONJOBS
           value: |
-            3,18,33,48 * * * * drush cron
+            3,18,33,48 * * * * flock -n /tmp/cron.lock.932b8586d96eb88e1574cb8a1223a0b964763c7d0ce90d9aff64d2d92e60fd8d -c 'drush cron'
         - name: SERVICE_NAME
           value: cli
         envFrom:


### PR DESCRIPTION
This change enforces that in-pod cronjobs have only one instance of the job running at any one time.

Specifically, this change fixes the issue where minutely cronjobs which take longer than a minute to run result in dozens of instances of the job running at the same time. In some cases this can cause Lagoon users to DoS themselves or use excessive CPU or memory resources.

Closes: https://github.com/uselagoon/lagoon-images/issues/172