### PR TITLE
chore: attempt to reduce race in messages

### DIFF
--- a/legacy/build-deploy-docker-compose.sh
+++ b/legacy/build-deploy-docker-compose.sh
@@ -1691,3 +1691,6 @@ if [ "$(featureFlag INSIGHTS)" = enabled ]; then
   previousStepEnd=${currentStepEnd}
 fi
 set -x
+
+# attempt to reduce race conditions in final messages to lagoon by delaying the completion of the build pod itself until the last status update is sent
+sleep 2


### PR DESCRIPTION
Looking at when a build completes, the final 2 messages of running and complete come through at the same time sometimes, this particular build resulted in a condition where the build was still `running` in the API. I think that the two workers in this actions-handler pod raced to see which one could actually update the deployment first and `running` ended up winning.

```
2023/03/22 01:46:33 (messageid:obtw64nv) lagoon-ui-pr-110/lagoon-build-s8vxhu: received deployment status update - running
2023/03/22 01:46:36 (messageid:wbnclrcu) lagoon-ui-pr-110/lagoon-build-s8vxhu: received deployment status update - running
2023/03/22 01:47:58 (messageid:kzai4em7) lagoon-ui-pr-110/lagoon-build-s8vxhu: received deployment status update - running
2023/03/22 01:47:58 (messageid:zzc5sy31) lagoon-ui-pr-110/lagoon-build-s8vxhu: received deployment status update - complete
2023/03/22 01:48:00 (messageid:zzc5sy31) lagoon-ui-pr-110/lagoon-build-s8vxhu: updated environment
```

This PR adds a sleep at the end to make it so that the final complete message comes through delayed to try and reduce this race condition. Just an experiment at the moment