### PR TITLE
change: improve message and fail sooner on failure to provision dbaas

### DIFF
--- a/legacy/scripts/exec-kubectl-mariadb-dbaas.sh
+++ b/legacy/scripts/exec-kubectl-mariadb-dbaas.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 
 # The operator can sometimes take a bit, wait until the details are available
-# We added a timeout of 10 minutes (120 retries) before exit
+# We added a timeout of 5 minutes (60 retries) before exit
 OPERATOR_COUNTER=1
-OPERATOR_TIMEOUT=180
+OPERATOR_TIMEOUT=60
 # use the secret name from the consumer to prevent credential clash
 until kubectl -n ${NAMESPACE} get mariadbconsumer/${SERVICE_NAME} -o yaml | shyaml get-value spec.consumer.database
 do
 if [ $OPERATOR_COUNTER -lt $OPERATOR_TIMEOUT ]; then
+    consumer_failed=$(kubectl -n ${NAMESPACE} get mariadbconsumer/${SERVICE_NAME} -o json | jq -r '.metadata.annotations."dbaas.amazee.io/failed"')
+    if [ "${consumer_failed}" == "true" ]; then
+        echo "Failed to provision a database. Contact your support team to investigate."
+        exit 1
+    fi
     let OPERATOR_COUNTER=OPERATOR_COUNTER+1
     echo "Service for ${SERVICE_NAME} not available yet, waiting for 5 secs"
     sleep 5

--- a/legacy/scripts/exec-kubectl-mongodb-dbaas.sh
+++ b/legacy/scripts/exec-kubectl-mongodb-dbaas.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 
 # The operator can sometimes take a bit, wait until the details are available
-# We added a timeout of 10 minutes (120 retries) before exit
+# We added a timeout of 5 minutes (60 retries) before exit
 OPERATOR_COUNTER=1
-OPERATOR_TIMEOUT=180
+OPERATOR_TIMEOUT=60
 # use the secret name from the consumer to prevent credential clash
 until kubectl -n ${NAMESPACE} get mongodbconsumer/${SERVICE_NAME} -o yaml | shyaml get-value spec.consumer.database
 do
 if [ $OPERATOR_COUNTER -lt $OPERATOR_TIMEOUT ]; then
+    consumer_failed=$(kubectl -n ${NAMESPACE} get mongodbconsumer/${SERVICE_NAME} -o json | jq -r '.metadata.annotations."dbaas.amazee.io/failed"')
+    if [ "${consumer_failed}" == "true" ]; then
+        echo "Failed to provision a database. Contact your support team to investigate."
+        exit 1
+    fi
     let OPERATOR_COUNTER=OPERATOR_COUNTER+1
     echo "Service for ${SERVICE_NAME} not available yet, waiting for 5 secs"
     sleep 5


### PR DESCRIPTION
This adds a message that the consumer failed to provision if the failure annotation is found on a resource.
Ideally this would point to some troubleshooting steps somewhere, but these do not exist at the moment.

Pushing this PR for now while working on troubleshooting steps. Developers can't really do this investigation as the error is with the dbaas-operator somewhere, and exposing the error message from the dbaas-operator is probably not the best idea.