### PR TITLE
refactor: prefer the service account token over the older deployer token

### DIFF
--- a/legacy/build-deploy.sh
+++ b/legacy/build-deploy.sh
@@ -62,11 +62,12 @@ PRIVATE_DOCKER_HUB_REGISTRY=0
 PRIVATE_EXTERNAL_REGISTRY=0
 
 set +x # reduce noise in build logs
-if [[ -f "/var/run/secrets/lagoon/deployer/token" ]]; then
-  DEPLOYER_TOKEN=$(cat /var/run/secrets/lagoon/deployer/token)
-else
+if [[ -f "/var/run/secrets/kubernetes.io/serviceaccount/token" ]]; then
   DEPLOYER_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
-fi
+else
+  if [[ -f "/var/run/secrets/lagoon/deployer/token" ]]; then
+    DEPLOYER_TOKEN=$(cat /var/run/secrets/lagoon/deployer/token)
+  fi
 if [ -z ${DEPLOYER_TOKEN} ]; then
   echo "No deployer token found"; exit 1;
 fi


### PR DESCRIPTION
Small refactor to the way the service account token is determined. This falls back to the older deployer token that was created prior to kubernetes 1.24, and prefers the service account token that is generated on demand by the build pods.

This reduces the possibility of the following warning appearing in build logs causing confusion
```
Warning: Use tokens from the TokenRequest API or manually created secret-based tokens instead of auto-generated secret-based tokens.
```