### PR TITLE
fix: add missing closing fi to if

### DIFF
--- a/legacy/build-deploy.sh
+++ b/legacy/build-deploy.sh
@@ -68,6 +68,7 @@ else
   if [[ -f "/var/run/secrets/lagoon/deployer/token" ]]; then
     DEPLOYER_TOKEN=$(cat /var/run/secrets/lagoon/deployer/token)
   fi
+fi
 if [ -z ${DEPLOYER_TOKEN} ]; then
   echo "No deployer token found"; exit 1;
 fi


### PR DESCRIPTION
Adds a missing `fi` to an if statement in the service account token check step