### PR TITLE
remove unknown spec.pod.metadata.labels from prebackuppods

### DIFF
--- a/legacy/helmcharts/mariadb-dbaas/templates/prebackuppod.yaml
+++ b/legacy/helmcharts/mariadb-dbaas/templates/prebackuppod.yaml
@@ -33,10 +33,6 @@ spec:
     && cat $dump && rm $dump"
   fileExtension: .{{ include "mariadb-dbaas.fullname" . }}.sql
   pod:
-    metadata:
-      labels:
-        prebackuppod: {{ include "mariadb-dbaas.fullname" . }}
-        {{- include "mariadb-dbaas.labels" . | nindent 8 }}
     spec:
       containers:
         - args:

--- a/legacy/helmcharts/mongodb-dbaas/templates/prebackuppod.yaml
+++ b/legacy/helmcharts/mongodb-dbaas/templates/prebackuppod.yaml
@@ -11,10 +11,6 @@ spec:
   backupCommand: /bin/sh -c "mongodump --uri=mongodb://${BACKUP_DB_USER}:${BACKUP_DB_PASSWORD}@${BACKUP_DB_HOST}:${BACKUP_DB_PORT}/${BACKUP_DB_NAME}?ssl=true&sslInsecure=true&tls=true&tlsInsecure=true --archive"
   fileExtension: .{{ include "mongodb-dbaas.fullname" . }}.bson
   pod:
-    metadata:
-      labels:
-        prebackuppod: {{ include "mongodb-dbaas.fullname" . }}
-        {{- include "mongodb-dbaas.labels" . | nindent 8 }}
     spec:
       containers:
         - args:

--- a/legacy/helmcharts/postgres-dbaas/templates/prebackuppod.yaml
+++ b/legacy/helmcharts/postgres-dbaas/templates/prebackuppod.yaml
@@ -19,10 +19,6 @@ spec:
     --format=t -w"
   fileExtension: .{{ include "postgres-dbaas.fullname" . }}.tar
   pod:
-    metadata:
-      labels:
-        prebackuppod: {{ include "postgres-dbaas.fullname" . }}
-        {{- include "postgres-dbaas.labels" . | nindent 8 }}
     spec:
       containers:
         - args:


### PR DESCRIPTION
Prior to Kubernetes 1.23 (https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/2885-server-side-unknown-field-validation) and enforced in 1.24, kubectl apply has allowed for kubectl apply to have unknown fields in default operation.

Every build contains:
```
Warning: unknown field "spec.pod.metadata.labels"
```

When upgrading the version of kubectl in this tool past 1.24, builds fail because of the unknown fields.

As these fields aren't present in the CRD, the labels aren't applied to prebackuppods, so they can be safely removed.