### PR TITLE
fix: tls cleanup error on ingress with no tls

### DIFF
--- a/legacy/build-deploy-docker-compose.sh
+++ b/legacy/build-deploy-docker-compose.sh
@@ -1766,7 +1766,7 @@ fi
 # remove any certificates for tls-acme false ingress to prevent reissuing attempts
 TLS_FALSE_INGRESSES=$(kubectl -n ${NAMESPACE} get ingress -o json | jq -r '.items[] | select(.metadata.annotations["kubernetes.io/tls-acme"] == "false") | .metadata.name')
 for TLS_FALSE_INGRESS in $TLS_FALSE_INGRESSES; do
-  TLS_SECRETS=$(kubectl -n ${NAMESPACE} get ingress ${TLS_FALSE_INGRESS} -o json | jq -r '.spec.tls[].secretName')
+  TLS_SECRETS=$(kubectl -n ${NAMESPACE} get ingress ${TLS_FALSE_INGRESS} -o json | jq -r '.spec.tls[]?.secretName')
   for TLS_SECRET in $TLS_SECRETS; do
     if kubectl -n ${NAMESPACE} get certificates.cert-manager.io ${TLS_SECRET} &> /dev/null; then
       echo ">> Cleaning up certificate for ${TLS_SECRET} as tls-acme is set to false"


### PR DESCRIPTION
Fixes an error introduced in #241 where attempting to cleanup tls certificates for an ingress that already doesn't have any tls certificates will fail the build.

The build failure error is: `jq: error (at <stdin>:175): Cannot iterate over null (null)` which is thrown at https://github.com/uselagoon/build-deploy-tool/blob/main/legacy/build-deploy-docker-compose.sh#L1769. The `jq` sequence includes `.spec.tls[]` which is not guaranteed to exist.

The fix is to use `[]?` to make `jq` treat it as optional.

Example ingress with a secret that needs to be cleaned
```
{
  "ingressClassName": "nginx",
  "rules": [
    {
      "host": "redacted",
      "http": {
        "paths": [
          {
            "backend": {
              "service": {
                "name": "nginx",
                "port": {
                  "name": "http"
                }
              }
            },
            "path": "/",
            "pathType": "Prefix"
          }
        ]
      }
    }
  ],
  "tls": [
    {
      "hosts": [
        "redacted"
      ],
      "secretName": "redacted-tls"
    }
  ]
}
```

Example ingress with no tls secrets
```
{
  "ingressClassName": "nginx",
  "rules": [
    {
      "host": "redacted",
      "http": {
        "paths": [
          {
            "backend": {
              "service": {
                "name": "nginx",
                "port": {
                  "name": "http"
                }
              }
            },
            "path": "/",
            "pathType": "Prefix"
          }
        ]
      }
    }
  ]
}
```