### PR TITLE
fix: use correct username in backup command for mongo prebackuppod

### DIFF
--- a/internal/templating/backups/template_prebackuppod.go
+++ b/internal/templating/backups/template_prebackuppod.go
@@ -356,7 +356,7 @@ pod:
       image: uselagoon/database-tools:latest
       imagePullPolicy: Always
       name: {{ .Name }}-prebackuppod`,
-	"mongodb-dbaas": `backupCommand: /bin/sh -c "mongodump --uri=mongodb://${BACKUP_DB_USER}:${BACKUP_DB_PASSWORD}@${BACKUP_DB_HOST}:${BACKUP_DB_PORT}/${BACKUP_DB_DATABASE}?ssl=true&sslInsecure=true&tls=true&tlsInsecure=true --archive"
+	"mongodb-dbaas": `backupCommand: /bin/sh -c "mongodump --uri=mongodb://${BACKUP_DB_USERNAME}:${BACKUP_DB_PASSWORD}@${BACKUP_DB_HOST}:${BACKUP_DB_PORT}/${BACKUP_DB_DATABASE}?ssl=true&sslInsecure=true&tls=true&tlsInsecure=true --archive"
 fileExtension: .{{ .Name }}.bson
 pod:
   spec:

--- a/internal/templating/backups/test-resources/result-prebackuppod3.yaml
+++ b/internal/templating/backups/test-resources/result-prebackuppod3.yaml
@@ -19,7 +19,7 @@ metadata:
     prebackuppod: mongodb-database
   name: mongodb-database-prebackuppod
 spec:
-  backupCommand: /bin/sh -c "mongodump --uri=mongodb://${BACKUP_DB_USER}:${BACKUP_DB_PASSWORD}@${BACKUP_DB_HOST}:${BACKUP_DB_PORT}/${BACKUP_DB_DATABASE}?ssl=true&sslInsecure=true&tls=true&tlsInsecure=true
+  backupCommand: /bin/sh -c "mongodump --uri=mongodb://${BACKUP_DB_USERNAME}:${BACKUP_DB_PASSWORD}@${BACKUP_DB_HOST}:${BACKUP_DB_PORT}/${BACKUP_DB_DATABASE}?ssl=true&sslInsecure=true&tls=true&tlsInsecure=true
     --archive"
   fileExtension: .mongodb-database.bson
   pod:


### PR DESCRIPTION
Just a small fix to the variable name for username in the backup command