### PR TITLE
chore: add other missing values for mongo prebackuppods

### DIFF
--- a/internal/templating/backups/template_prebackuppod.go
+++ b/internal/templating/backups/template_prebackuppod.go
@@ -385,6 +385,26 @@ pod:
           configMapKeyRef:
             key: {{ .Name | VarFix }}_DATABASE
             name: lagoon-env
+      - name: BACKUP_DB_PORT
+        valueFrom:
+          configMapKeyRef:
+            key: {{ .Name | VarFix }}_PORT
+            name: lagoon-env
+      - name: BACKUP_DB_AUTHSOURCE
+        valueFrom:
+          configMapKeyRef:
+            key: {{ .Name | VarFix }}_AUTHSOURCE
+            name: lagoon-env
+      - name: BACKUP_DB_AUTHMECHANISM
+        valueFrom:
+          configMapKeyRef:
+            key: {{ .Name | VarFix }}_AUTHMECHANISM
+            name: lagoon-env
+      - name: BACKUP_DB_AUTHTLS
+        valueFrom:
+          configMapKeyRef:
+            key: {{ .Name | VarFix }}_AUTHTLS
+            name: lagoon-env
       image: uselagoon/database-tools:latest
       imagePullPolicy: Always
       name: {{ .Name }}-prebackuppod`,

--- a/internal/templating/backups/test-resources/result-prebackuppod3.yaml
+++ b/internal/templating/backups/test-resources/result-prebackuppod3.yaml
@@ -19,8 +19,10 @@ metadata:
     prebackuppod: mongodb-database
   name: mongodb-database-prebackuppod
 spec:
-  backupCommand: /bin/sh -c "mongodump --uri=mongodb://${BACKUP_DB_USERNAME}:${BACKUP_DB_PASSWORD}@${BACKUP_DB_HOST}:${BACKUP_DB_PORT}/${BACKUP_DB_DATABASE}?ssl=true&sslInsecure=true&tls=true&tlsInsecure=true
-    --archive"
+  backupCommand: /bin/sh -c "dump=$(mktemp) && mongodump --quiet --ssl --tlsInsecure
+    --username=${BACKUP_DB_USERNAME} --password=${BACKUP_DB_PASSWORD} --host=${BACKUP_DB_HOST}:${BACKUP_DB_PORT}
+    --db=${BACKUP_DB_DATABASE} --authenticationDatabase=${BACKUP_DB_AUTHSOURCE} --authenticationMechanism=${BACKUP_DB_AUTHMECHANISM}
+    --archive=$dump && cat $dump && rm $dump"
   fileExtension: .mongodb-database.bson
   pod:
     metadata: {}

--- a/internal/templating/backups/test-resources/result-prebackuppod3.yaml
+++ b/internal/templating/backups/test-resources/result-prebackuppod3.yaml
@@ -50,6 +50,26 @@ spec:
             configMapKeyRef:
               key: MONGODB_DATABASE_DATABASE
               name: lagoon-env
+        - name: BACKUP_DB_PORT
+          valueFrom:
+            configMapKeyRef:
+              key: MONGODB_DATABASE_PORT
+              name: lagoon-env
+        - name: BACKUP_DB_AUTHSOURCE
+          valueFrom:
+            configMapKeyRef:
+              key: MONGODB_DATABASE_AUTHSOURCE
+              name: lagoon-env
+        - name: BACKUP_DB_AUTHMECHANISM
+          valueFrom:
+            configMapKeyRef:
+              key: MONGODB_DATABASE_AUTHMECHANISM
+              name: lagoon-env
+        - name: BACKUP_DB_AUTHTLS
+          valueFrom:
+            configMapKeyRef:
+              key: MONGODB_DATABASE_AUTHTLS
+              name: lagoon-env
         - name: BACKUP_DB_READREPLICA_HOSTS
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
Just minor work to add the other missing variables for mongo prebackuppods. These aren't actually used by the backup command, but they may get used in the future.

Fixes the backup command to also support mongodb and documentdb backups and dumps the archive which can be restored using `mongorestore`