### PR TITLE
fix: resource overrides in nginx-php templates

### DIFF
--- a/legacy/helmcharts/nginx-php-persistent/templates/_helpers.tpl
+++ b/legacy/helmcharts/nginx-php-persistent/templates/_helpers.tpl
@@ -135,3 +135,16 @@ Generate path for twig storage emptyDir
 {{- define "nginx-php-persistent.twig-storage.path" -}}
 {{- printf "%s/php" .Values.persistentStorage.path }}
 {{- end -}}
+
+{{/*
+Merge resources from global over resources defined in the values
+*/}}
+{{- define "resources" -}}
+{{- $value := dict -}}
+{{- range (rest .) -}}
+  {{- $value = merge $value . -}}
+{{- end -}}
+{{- if $value -}}
+{{- toYaml $value }}
+{{- end }}
+{{- end -}}

--- a/legacy/helmcharts/nginx-php-persistent/templates/deployment.yaml
+++ b/legacy/helmcharts/nginx-php-persistent/templates/deployment.yaml
@@ -109,8 +109,7 @@ spec:
             {{- toYaml .Values.dynamicSecretMounts | nindent 12 }}
           {{- end }}
           resources:
-            {{- toYaml .Values.resources.nginx | nindent 12 }}
-
+            {{- include "resources" (list "resources" .Values.resources .Values.containerResources.nginx) | nindent 12 }}
         - image: {{ .Values.images.php | quote }}
           name: "php"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -146,7 +145,7 @@ spec:
             {{- toYaml .Values.dynamicSecretMounts | nindent 12 }}
           {{- end }}
           resources:
-            {{- toYaml .Values.resources.php | nindent 12 }}
+            {{- include "resources" (list "resources" .Values.resources .Values.containerResources.php ) | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/legacy/helmcharts/nginx-php-persistent/values.yaml
+++ b/legacy/helmcharts/nginx-php-persistent/values.yaml
@@ -40,7 +40,7 @@ fastly:
 #   serviceId: ''
 #   apiSecretName: ''
 
-resources:
+containerResources:
   nginx:
     # limits:
     #   cpu: 100m
@@ -55,6 +55,8 @@ resources:
     requests:
       cpu: 10m
       memory: 100Mi
+
+resources: {}
 
 nodeSelector: {}
 

--- a/legacy/helmcharts/nginx-php/templates/_helpers.tpl
+++ b/legacy/helmcharts/nginx-php/templates/_helpers.tpl
@@ -113,3 +113,16 @@ lagoon.sh/prHeadBranch: {{ .Values.prHeadBranch | quote }}
 lagoon.sh/prBaseBranch: {{ .Values.prBaseBranch | quote }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Merge resources from global over resources defined in the values
+*/}}
+{{- define "resources" -}}
+{{- $value := dict -}}
+{{- range (rest .) -}}
+  {{- $value = merge $value . -}}
+{{- end -}}
+{{- if $value -}}
+{{- toYaml $value }}
+{{- end }}
+{{- end -}}

--- a/legacy/helmcharts/nginx-php/templates/deployment.yaml
+++ b/legacy/helmcharts/nginx-php/templates/deployment.yaml
@@ -72,7 +72,7 @@ spec:
             - configMapRef:
                 name: lagoon-env
           resources:
-            {{- toYaml .Values.resources.nginx | nindent 12 }}
+            {{- include "resources" (list "resources" .Values.resources .Values.containerResources.nginx ) | nindent 12 }}
           {{- if .Values.dynamicSecretMounts }}
           volumeMounts:
             {{- toYaml .Values.dynamicSecretMounts | nindent 12 }}
@@ -105,7 +105,7 @@ spec:
             - name: NGINX_FASTCGI_PASS
               value: '127.0.0.1'
           resources:
-            {{- toYaml .Values.resources.php | nindent 12 }}
+            {{- include "resources" (list "resources" .Values.resources .Values.containerResources.php ) | nindent 12 }}
           {{- if .Values.dynamicSecretMounts }}
           volumeMounts:
             {{- toYaml .Values.dynamicSecretMounts | nindent 12 }}

--- a/legacy/helmcharts/nginx-php/values.yaml
+++ b/legacy/helmcharts/nginx-php/values.yaml
@@ -37,7 +37,7 @@ fastly:
 #   serviceId: ''
 #   apiSecretName: ''
 
-resources:
+containerResources:
   nginx:
     # limits:
     #   cpu: 100m
@@ -52,6 +52,8 @@ resources:
     requests:
       cpu: 10m
       memory: 100Mi
+
+resources: {}
 
 nodeSelector: {}
 


### PR DESCRIPTION
Just a fix that allows for the resources that get defined by overrides (like container memory limits) to get applied to nginx-php based templates, which didn't happen before because they had container specific definitions that meant the overrides never got applied.