### PR TITLE
fix: actually source the namespace

### DIFF
--- a/cmd/template_backups_test.go
+++ b/cmd/template_backups_test.go
@@ -37,6 +37,7 @@ func TestBackupTemplateGeneration(t *testing.T) {
 		controllerDevSchedule string
 		controllerPRSchedule  string
 		k8upVersion           string
+		namespace             string
 	}
 	tests := []struct {
 		name    string
@@ -51,6 +52,7 @@ func TestBackupTemplateGeneration(t *testing.T) {
 				statusPageID:    "statuspageid",
 				projectName:     "example-project",
 				environmentName: "main",
+				namespace:       "example-project-main",
 				environmentType: "production",
 				buildType:       "branch",
 				lagoonVersion:   "v2.7.x",
@@ -70,6 +72,7 @@ func TestBackupTemplateGeneration(t *testing.T) {
 				statusPageID:    "statuspageid",
 				projectName:     "example-project",
 				environmentName: "main",
+				namespace:       "example-project-main",
 				environmentType: "development",
 				buildType:       "branch",
 				lagoonVersion:   "v2.7.x",
@@ -89,6 +92,7 @@ func TestBackupTemplateGeneration(t *testing.T) {
 				statusPageID:    "statuspageid",
 				projectName:     "example-project",
 				environmentName: "main",
+				namespace:       "example-project-main",
 				environmentType: "production",
 				buildType:       "branch",
 				lagoonVersion:   "v2.7.x",
@@ -108,6 +112,7 @@ func TestBackupTemplateGeneration(t *testing.T) {
 				statusPageID:    "statuspageid",
 				projectName:     "example-project",
 				environmentName: "main",
+				namespace:       "example-project-main",
 				environmentType: "development",
 				buildType:       "pullrequest",
 				prNumber:        "123",
@@ -130,6 +135,7 @@ func TestBackupTemplateGeneration(t *testing.T) {
 				statusPageID:    "statuspageid",
 				projectName:     "example-project",
 				environmentName: "main",
+				namespace:       "example-project-main",
 				environmentType: "development",
 				buildType:       "pullrequest",
 				prNumber:        "123",
@@ -152,6 +158,7 @@ func TestBackupTemplateGeneration(t *testing.T) {
 				statusPageID:    "statuspageid",
 				projectName:     "example-project",
 				environmentName: "main",
+				namespace:       "example-project-main",
 				environmentType: "production",
 				buildType:       "branch",
 				lagoonVersion:   "v2.7.x",
@@ -181,6 +188,10 @@ func TestBackupTemplateGeneration(t *testing.T) {
 				t.Errorf("%v", err)
 			}
 			err = os.Setenv("ENVIRONMENT", tt.args.environmentName)
+			if err != nil {
+				t.Errorf("%v", err)
+			}
+			err = os.Setenv("NAMESPACE", tt.args.namespace)
 			if err != nil {
 				t.Errorf("%v", err)
 			}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -53,6 +53,7 @@ type GeneratorInput struct {
 	IgnoreMissingEnvFiles    bool
 	Debug                    bool
 	DBaaSClient              *dbaasclient.Client
+	Namespace                string
 }
 
 func NewGenerator(
@@ -74,6 +75,7 @@ func NewGenerator(
 	monitoringStatusPageID := helpers.GetEnv("MONITORING_STATUSPAGEID", generator.MonitoringStatusPageID, generator.Debug)
 	projectName := helpers.GetEnv("PROJECT", generator.ProjectName, generator.Debug)
 	environmentName := helpers.GetEnv("ENVIRONMENT", generator.EnvironmentName, generator.Debug)
+	namespace := helpers.GetEnv("NAMESPACE", generator.Namespace, generator.Debug)
 	branch := helpers.GetEnv("BRANCH", generator.Branch, generator.Debug)
 	prNumber := helpers.GetEnv("PR_NUMBER", generator.PRNumber, generator.Debug)
 	prTitle := helpers.GetEnv("PR_NUMBER", generator.PRTitle, generator.Debug)
@@ -110,6 +112,7 @@ func NewGenerator(
 	// start saving values into the build values variable
 	buildValues.Project = projectName
 	buildValues.Environment = environmentName
+	buildValues.Namespace = namespace
 	buildValues.EnvironmentType = environmentType
 	buildValues.BuildType = buildType
 	buildValues.LagoonVersion = lagoonVersion

--- a/test-resources/template-backups/test1-results/k8up-lagoon-backup-schedule.yaml
+++ b/test-resources/template-backups/test1-results/k8up-lagoon-backup-schedule.yaml
@@ -27,16 +27,16 @@ spec:
       bucket: baas-example-project
   backup:
     resources: {}
-    schedule: 5 23 * * *
+    schedule: 48 22 * * *
   check:
     resources: {}
-    schedule: 5 7 * * 1
+    schedule: 48 5 * * 1
   prune:
     resources: {}
     retention:
       keepDaily: 7
       keepMonthly: 1
       keepWeekly: 6
-    schedule: 5 4 * * 0
+    schedule: 48 3 * * 0
   resourceRequirementsTemplate: {}
 status: {}

--- a/test-resources/template-backups/test2-results/k8up-lagoon-backup-schedule.yaml
+++ b/test-resources/template-backups/test2-results/k8up-lagoon-backup-schedule.yaml
@@ -30,13 +30,13 @@ spec:
     schedule: 1,31 23 * * *
   check:
     resources: {}
-    schedule: 5 7 * * 1
+    schedule: 48 5 * * 1
   prune:
     resources: {}
     retention:
       keepDaily: 7
       keepMonthly: 1
       keepWeekly: 6
-    schedule: 5 4 * * 0
+    schedule: 48 3 * * 0
   resourceRequirementsTemplate: {}
 status: {}

--- a/test-resources/template-backups/test3-results/k8up-lagoon-backup-schedule.yaml
+++ b/test-resources/template-backups/test3-results/k8up-lagoon-backup-schedule.yaml
@@ -27,10 +27,10 @@ spec:
       bucket: baas-example-project
   backup:
     resources: {}
-    schedule: 5 23 * * *
+    schedule: 48 22 * * *
   check:
     resources: {}
-    schedule: 5 7 * * 1
+    schedule: 48 5 * * 1
   prune:
     resources: {}
     retention:
@@ -38,6 +38,6 @@ spec:
       keepHourly: 10
       keepMonthly: 10
       keepWeekly: 10
-    schedule: 5 4 * * 0
+    schedule: 48 3 * * 0
   resourceRequirementsTemplate: {}
 status: {}

--- a/test-resources/template-backups/test4-results/k8up-lagoon-backup-schedule.yaml
+++ b/test-resources/template-backups/test4-results/k8up-lagoon-backup-schedule.yaml
@@ -38,14 +38,14 @@ spec:
     schedule: 3,33 12 * * *
   check:
     resources: {}
-    schedule: 5 7 * * 1
+    schedule: 48 5 * * 1
   prune:
     resources: {}
     retention:
       keepDaily: 7
       keepMonthly: 1
       keepWeekly: 6
-    schedule: 5 4 * * 0
+    schedule: 48 3 * * 0
   resourceRequirementsTemplate: {}
 status: {}
 ---

--- a/test-resources/template-backups/test5-results/k8up-lagoon-backup-schedule.yaml
+++ b/test-resources/template-backups/test5-results/k8up-lagoon-backup-schedule.yaml
@@ -32,14 +32,14 @@ spec:
     schedule: 3,33 12 * * *
   check:
     resources: {}
-    schedule: 5 7 * * 1
+    schedule: 48 5 * * 1
   prune:
     resources: {}
     retention:
       keepDaily: 7
       keepMonthly: 1
       keepWeekly: 6
-    schedule: 5 4 * * 0
+    schedule: 48 3 * * 0
   resourceRequirementsTemplate: {}
 status: {}
 ---

--- a/test-resources/template-backups/test6-results/k8up-lagoon-backup-schedule.yaml
+++ b/test-resources/template-backups/test6-results/k8up-lagoon-backup-schedule.yaml
@@ -27,10 +27,10 @@ spec:
       bucket: baas-example-project
   backup:
     resources: {}
-    schedule: 5,20,35,50 5 * * 0
+    schedule: 3,18,33,48 5 * * 0
   check:
     resources: {}
-    schedule: 5 7 * * 1
+    schedule: 48 5 * * 1
   prune:
     resources: {}
     retention:
@@ -38,6 +38,6 @@ spec:
       keepHourly: 10
       keepMonthly: 12
       keepWeekly: 16
-    schedule: 5 4 * * 0
+    schedule: 48 3 * * 0
   resourceRequirementsTemplate: {}
 status: {}


### PR DESCRIPTION
Fix to actually source the namespace from the build for use in templating backup schedules. Backup schedules are the only part of a build step in the tool that actually uses the namespace currently.