### PR TITLE
chore: allow images merging against a release branch to build images

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - 'main'
+      - 'release/*'
 
 jobs:
   docker:


### PR DESCRIPTION
This would allow us to create `release/*` branches, then we can build PR images for hotfixes against a particular release tag/version