### PR TITLE
refactor: namespace sourcing from the serviceaccount file if found

### DIFF
--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base32"
 	"encoding/gob"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -169,6 +170,18 @@ func WriteTemplateFile(templateOutputFile string, data []byte) {
 type EnvironmentVariable struct {
 	Name  string
 	Value string
+}
+
+// Try and get the namespace name from the serviceaccount location if it exists
+func GetNamespace(namespace, filename string) (string, error) {
+	if _, err := os.Stat(filename); !errors.Is(err, os.ErrNotExist) {
+		nsb, err := os.ReadFile(filename)
+		if err != nil {
+			return "", err
+		}
+		namespace = strings.Trim(string(nsb), "\n ")
+	}
+	return namespace, nil
 }
 
 func UnsetEnvVars(localVars []EnvironmentVariable) {

--- a/internal/helpers/helpers_test.go
+++ b/internal/helpers/helpers_test.go
@@ -573,3 +573,45 @@ func TestCheckLabelLength(t *testing.T) {
 		})
 	}
 }
+
+func TestGetNamespace(t *testing.T) {
+	type args struct {
+		namespace string
+		filename  string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "test1 - no file",
+			args: args{
+				namespace: "test-namespace",
+				filename:  "test-resources/test1",
+			},
+			want: "test-namespace",
+		},
+		{
+			name: "test2 - test namespace file",
+			args: args{
+				namespace: "a-namespace",
+				filename:  "test-resources/test2",
+			},
+			want: "test-namespace",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetNamespace(tt.args.namespace, tt.args.filename)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetNamespace() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetNamespace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/helpers/test-resources/test2
+++ b/internal/helpers/test-resources/test2
@@ -1,0 +1,1 @@
+test-namespace


### PR DESCRIPTION
Just a fix up from #275 to source the namespace from the service account file if one is found