### PR TITLE
fix: dioscuri migration uses invalid base64 decode flag

### DIFF
--- a/legacy/build-deploy-docker-compose.sh
+++ b/legacy/build-deploy-docker-compose.sh
@@ -1344,11 +1344,8 @@ ROUTES=$(kubectl -n ${NAMESPACE} get ingress --sort-by='{.metadata.name}' -l "ac
 
 # swap dioscuri for activestanby label
 for ingress in $(kubectl  -n ${NAMESPACE} get ingress -l "dioscuri.amazee.io/migrate" -o json | jq -r '.items[] | @base64'); do
-    _jq() {
-     echo ${ingress} | base64 --decode | jq -r ${1}
-    }
-    INGRESS_NAME=$(echo $(_jq '.') | jq -r '.metadata.name')
-    MIGRATE_VALUE=$(echo $(_jq '.') | jq -r '.metadata.labels["dioscuri.amazee.io/migrate"] // false ')
+    INGRESS_NAME=$(echo $ingress | jq -Rr '@base64d | fromjson | .metadata.name')
+    MIGRATE_VALUE=$(echo $ingress | jq -Rr '@base64d | fromjson | .metadata.labels["dioscuri.amazee.io/migrate"] // false')
     PATCH='{
   "metadata": {
     "labels": {


### PR DESCRIPTION
An error was introduced in #265 due to invalid `base64` flag:

```
base64: unrecognized option: decode
BusyBox v1.36.0 (2023-05-05 06:41:49 UTC) multi-call binary.

Usage: base64 [-d] [-w COL] [FILE]

Base64 encode or decode FILE to standard output

	-d	Decode data
	-w COL	Wrap lines at COL (default 76, 0 disables)
```

This PR removes the call to `base64` altogether in favor of `jq`. Tested in a live `build-deploy-tool` pod.