### PR TITLE
refactor: remove the duplicated namespace calculation for the generator value

### DIFF
--- a/cmd/tasks_run_test.go
+++ b/cmd/tasks_run_test.go
@@ -143,8 +143,6 @@ func Test_runTasks(t *testing.T) {
 		},
 	}
 
-	oldNamespace := namespace
-	namespace = "default"
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := runTasks(tt.args.taskRunner, tt.args.lYAML.Tasks.Prerollout, tt.args.lagoonConditionalEvaluationEnvironment); (err != nil) != tt.wantErr {
@@ -153,7 +151,6 @@ func Test_runTasks(t *testing.T) {
 
 		})
 	}
-	namespace = oldNamespace
 }
 
 func Test_iterateTaskGenerator(t *testing.T) {


### PR DESCRIPTION
Just removing the duplicated namespace calculation step from the tasks runner to use the value that comes from the generator output now that #278 is merged and resolves the namespace being provided to the generator.