### PR TITLE
fix: cron generator to support hourly interval and default backup schedule variable

### DIFF
--- a/cmd/template_backups_test.go
+++ b/cmd/template_backups_test.go
@@ -38,6 +38,7 @@ func TestBackupTemplateGeneration(t *testing.T) {
 		controllerPRSchedule  string
 		k8upVersion           string
 		namespace             string
+		defaultBackupSchedule string
 	}
 	tests := []struct {
 		name    string
@@ -171,6 +172,27 @@ func TestBackupTemplateGeneration(t *testing.T) {
 			},
 			want: "../test-resources/template-backups/test6-results",
 		},
+		{
+			name: "test7",
+			args: args{
+				alertContact:          "alertcontact",
+				statusPageID:          "statuspageid",
+				projectName:           "example-project",
+				environmentName:       "main",
+				namespace:             "example-project-main",
+				environmentType:       "production",
+				buildType:             "branch",
+				lagoonVersion:         "v2.7.x",
+				branch:                "main",
+				k8upVersion:           "v1",
+				projectVars:           `[{"name":"LAGOON_SYSTEM_ROUTER_PATTERN","value":"${service}-${project}-${environment}.example.com","scope":"internal_system"},{"name":"LAGOON_FASTLY_SERVICE_IDS","value":"example.com:service-id:true:annotationscom","scope":"build"}]`,
+				envVars:               `[]`,
+				lagoonYAML:            "../test-resources/template-backups/test7/lagoon.yml",
+				templatePath:          "../test-resources/template-backups/output",
+				defaultBackupSchedule: "M */6 * * *",
+			},
+			want: "../test-resources/template-backups/test7-results",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -255,6 +277,10 @@ func TestBackupTemplateGeneration(t *testing.T) {
 			if err != nil {
 				t.Errorf("%v", err)
 			}
+			err = os.Setenv("DEFAULT_BACKUP_SCHEDULE", tt.args.defaultBackupSchedule)
+			if err != nil {
+				t.Errorf("%v", err)
+			}
 			generator, err := generatorInput(false)
 			if err != nil {
 				t.Errorf("%v", err)
@@ -335,7 +361,7 @@ func TestBackupTemplateGeneration(t *testing.T) {
 				t.Errorf("resulting templates do not match")
 			}
 			t.Cleanup(func() {
-				helpers.UnsetEnvVars(nil)
+				helpers.UnsetEnvVars([]helpers.EnvironmentVariable{{Name: "DEFAULT_BACKUP_SCHEDULE"}})
 			})
 		})
 	}

--- a/internal/generator/backups.go
+++ b/internal/generator/backups.go
@@ -10,7 +10,6 @@ import (
 const (
 	defaultCheckSchedule          = "M H(5-8) * * 1"
 	defaultPruneSchedule          = "M H(3-5) * * 0"
-	defaultBackupSchedule         = "M H(22-2) * * *"
 	hourlyDefaultBackupRetention  = 0
 	dailyDefaultBackupRetention   = 7
 	weeklyDefaultBackupRetention  = 6

--- a/internal/generator/backups.go
+++ b/internal/generator/backups.go
@@ -30,7 +30,7 @@ func generateBackupValues(
 	// builds need to calculate a new schedule from multiple places for backups
 	// create a new schedule placeholder set to the default value so it can be adjusted through this
 	// generator
-	newBackupSchedule := defaultBackupSchedule
+	newBackupSchedule := buildValues.DefaultBackupSchedule
 
 	customBackupConfig := CheckFeatureFlag("CUSTOM_BACKUP_CONFIG", mergedVariables, debug)
 	if customBackupConfig == "enabled" {

--- a/internal/generator/backups_test.go
+++ b/internal/generator/backups_test.go
@@ -28,19 +28,21 @@ func Test_generateBackupValues(t *testing.T) {
 			name: "test1",
 			args: args{
 				buildValues: &BuildValues{
-					BuildType:       "branch",
-					EnvironmentType: "development",
-					Project:         "example-project",
-					Namespace:       "example-com-main",
+					BuildType:             "branch",
+					EnvironmentType:       "development",
+					Project:               "example-project",
+					Namespace:             "example-com-main",
+					DefaultBackupSchedule: "M H(22-2) * * *",
 				},
 				lYAML:           &lagoon.YAML{},
 				mergedVariables: []lagoon.EnvironmentVariable{},
 			},
 			want: &BuildValues{
-				BuildType:       "branch",
-				EnvironmentType: "development",
-				Project:         "example-project",
-				Namespace:       "example-com-main",
+				BuildType:             "branch",
+				EnvironmentType:       "development",
+				Project:               "example-project",
+				Namespace:             "example-com-main",
+				DefaultBackupSchedule: "M H(22-2) * * *",
 				Backup: BackupConfiguration{
 					BackupSchedule: "31 1 * * *",
 					CheckSchedule:  "31 6 * * 1",
@@ -59,10 +61,11 @@ func Test_generateBackupValues(t *testing.T) {
 			name: "test2 - dev schedule from lagoon api variable",
 			args: args{
 				buildValues: &BuildValues{
-					BuildType:       "branch",
-					EnvironmentType: "development",
-					Project:         "example-project",
-					Namespace:       "example-com-main",
+					BuildType:             "branch",
+					EnvironmentType:       "development",
+					Project:               "example-project",
+					Namespace:             "example-com-main",
+					DefaultBackupSchedule: "M H(22-2) * * *",
 				},
 				lYAML: &lagoon.YAML{},
 				mergedVariables: []lagoon.EnvironmentVariable{
@@ -71,10 +74,11 @@ func Test_generateBackupValues(t *testing.T) {
 				},
 			},
 			want: &BuildValues{
-				BuildType:       "branch",
-				EnvironmentType: "development",
-				Project:         "example-project",
-				Namespace:       "example-com-main",
+				BuildType:             "branch",
+				EnvironmentType:       "development",
+				Project:               "example-project",
+				Namespace:             "example-com-main",
+				DefaultBackupSchedule: "M H(22-2) * * *",
 				Backup: BackupConfiguration{
 					BackupSchedule: "1,16,31,46 23 * * 0-5",
 					CheckSchedule:  "31 6 * * 1",
@@ -93,10 +97,11 @@ func Test_generateBackupValues(t *testing.T) {
 			name: "test3 - dev schedule from build pod variable",
 			args: args{
 				buildValues: &BuildValues{
-					BuildType:       "branch",
-					EnvironmentType: "development",
-					Project:         "example-project",
-					Namespace:       "example-com-main",
+					BuildType:             "branch",
+					EnvironmentType:       "development",
+					Project:               "example-project",
+					Namespace:             "example-com-main",
+					DefaultBackupSchedule: "M H(22-2) * * *",
 				},
 				lYAML: &lagoon.YAML{},
 				mergedVariables: []lagoon.EnvironmentVariable{
@@ -107,10 +112,11 @@ func Test_generateBackupValues(t *testing.T) {
 				{Name: "LAGOON_FEATURE_BACKUP_DEV_SCHEDULE", Value: "1,16,31,46 23 * * 0-5"},
 			},
 			want: &BuildValues{
-				BuildType:       "branch",
-				EnvironmentType: "development",
-				Project:         "example-project",
-				Namespace:       "example-com-main",
+				BuildType:             "branch",
+				EnvironmentType:       "development",
+				Project:               "example-project",
+				Namespace:             "example-com-main",
+				DefaultBackupSchedule: "M H(22-2) * * *",
 				Backup: BackupConfiguration{
 					BackupSchedule: "1,16,31,46 23 * * 0-5",
 					CheckSchedule:  "31 6 * * 1",
@@ -129,10 +135,11 @@ func Test_generateBackupValues(t *testing.T) {
 			name: "test4- pr schedule from lagoon api variable",
 			args: args{
 				buildValues: &BuildValues{
-					BuildType:       "pullrequest",
-					EnvironmentType: "development",
-					Project:         "example-project",
-					Namespace:       "example-com-main",
+					BuildType:             "pullrequest",
+					EnvironmentType:       "development",
+					Project:               "example-project",
+					Namespace:             "example-com-main",
+					DefaultBackupSchedule: "M H(22-2) * * *",
 				},
 				lYAML: &lagoon.YAML{},
 				mergedVariables: []lagoon.EnvironmentVariable{
@@ -141,10 +148,11 @@ func Test_generateBackupValues(t *testing.T) {
 				},
 			},
 			want: &BuildValues{
-				BuildType:       "pullrequest",
-				EnvironmentType: "development",
-				Project:         "example-project",
-				Namespace:       "example-com-main",
+				BuildType:             "pullrequest",
+				EnvironmentType:       "development",
+				Project:               "example-project",
+				Namespace:             "example-com-main",
+				DefaultBackupSchedule: "M H(22-2) * * *",
 				Backup: BackupConfiguration{
 					BackupSchedule: "1,16,31,46 23 * * 0-5",
 					CheckSchedule:  "31 6 * * 1",
@@ -163,10 +171,11 @@ func Test_generateBackupValues(t *testing.T) {
 			name: "test5 - pr schedule from build pod variable",
 			args: args{
 				buildValues: &BuildValues{
-					BuildType:       "pullrequest",
-					EnvironmentType: "development",
-					Project:         "example-project",
-					Namespace:       "example-com-main",
+					BuildType:             "pullrequest",
+					EnvironmentType:       "development",
+					Project:               "example-project",
+					Namespace:             "example-com-main",
+					DefaultBackupSchedule: "M H(22-2) * * *",
 				},
 				lYAML: &lagoon.YAML{},
 				mergedVariables: []lagoon.EnvironmentVariable{
@@ -177,10 +186,11 @@ func Test_generateBackupValues(t *testing.T) {
 				{Name: "LAGOON_FEATURE_BACKUP_PR_SCHEDULE", Value: "1,16,31,46 23 * * 0-5"},
 			},
 			want: &BuildValues{
-				BuildType:       "pullrequest",
-				EnvironmentType: "development",
-				Project:         "example-project",
-				Namespace:       "example-com-main",
+				BuildType:             "pullrequest",
+				EnvironmentType:       "development",
+				Project:               "example-project",
+				Namespace:             "example-com-main",
+				DefaultBackupSchedule: "M H(22-2) * * *",
 				Backup: BackupConfiguration{
 					BackupSchedule: "1,16,31,46 23 * * 0-5",
 					CheckSchedule:  "31 6 * * 1",
@@ -199,10 +209,11 @@ func Test_generateBackupValues(t *testing.T) {
 			name: "test6 - pr env with dev schedule from lagoon api variable",
 			args: args{
 				buildValues: &BuildValues{
-					BuildType:       "pullrequest",
-					EnvironmentType: "development",
-					Project:         "example-project",
-					Namespace:       "example-com-main",
+					BuildType:             "pullrequest",
+					EnvironmentType:       "development",
+					Project:               "example-project",
+					Namespace:             "example-com-main",
+					DefaultBackupSchedule: "M H(22-2) * * *",
 				},
 				lYAML: &lagoon.YAML{},
 				mergedVariables: []lagoon.EnvironmentVariable{
@@ -211,10 +222,11 @@ func Test_generateBackupValues(t *testing.T) {
 				},
 			},
 			want: &BuildValues{
-				BuildType:       "pullrequest",
-				EnvironmentType: "development",
-				Project:         "example-project",
-				Namespace:       "example-com-main",
+				BuildType:             "pullrequest",
+				EnvironmentType:       "development",
+				Project:               "example-project",
+				Namespace:             "example-com-main",
+				DefaultBackupSchedule: "M H(22-2) * * *",
 				Backup: BackupConfiguration{
 					BackupSchedule: "1,16,31,46 23 * * 0-5",
 					CheckSchedule:  "31 6 * * 1",
@@ -233,10 +245,11 @@ func Test_generateBackupValues(t *testing.T) {
 			name: "test7 - pr env with dev schedule from build pod variable",
 			args: args{
 				buildValues: &BuildValues{
-					BuildType:       "pullrequest",
-					EnvironmentType: "development",
-					Project:         "example-project",
-					Namespace:       "example-com-main",
+					BuildType:             "pullrequest",
+					EnvironmentType:       "development",
+					Project:               "example-project",
+					Namespace:             "example-com-main",
+					DefaultBackupSchedule: "M H(22-2) * * *",
 				},
 				lYAML: &lagoon.YAML{},
 				mergedVariables: []lagoon.EnvironmentVariable{
@@ -247,10 +260,11 @@ func Test_generateBackupValues(t *testing.T) {
 				{Name: "LAGOON_FEATURE_BACKUP_DEV_SCHEDULE", Value: "1,16,31,46 23 * * 0-5"},
 			},
 			want: &BuildValues{
-				BuildType:       "pullrequest",
-				EnvironmentType: "development",
-				Project:         "example-project",
-				Namespace:       "example-com-main",
+				BuildType:             "pullrequest",
+				EnvironmentType:       "development",
+				Project:               "example-project",
+				Namespace:             "example-com-main",
+				DefaultBackupSchedule: "M H(22-2) * * *",
 				Backup: BackupConfiguration{
 					BackupSchedule: "1,16,31,46 23 * * 0-5",
 					CheckSchedule:  "31 6 * * 1",
@@ -269,10 +283,11 @@ func Test_generateBackupValues(t *testing.T) {
 			name: "test8 - production with lagoon yaml overrides",
 			args: args{
 				buildValues: &BuildValues{
-					BuildType:       "branch",
-					EnvironmentType: "production",
-					Project:         "example-project",
-					Namespace:       "example-com-main",
+					BuildType:             "branch",
+					EnvironmentType:       "production",
+					Project:               "example-project",
+					Namespace:             "example-com-main",
+					DefaultBackupSchedule: "M H(22-2) * * *",
 				},
 				lYAML: &lagoon.YAML{
 					BackupRetention: lagoon.BackupRetention{
@@ -290,10 +305,11 @@ func Test_generateBackupValues(t *testing.T) {
 				mergedVariables: []lagoon.EnvironmentVariable{},
 			},
 			want: &BuildValues{
-				BuildType:       "branch",
-				EnvironmentType: "production",
-				Project:         "example-project",
-				Namespace:       "example-com-main",
+				BuildType:             "branch",
+				EnvironmentType:       "production",
+				Project:               "example-project",
+				Namespace:             "example-com-main",
+				DefaultBackupSchedule: "M H(22-2) * * *",
 				Backup: BackupConfiguration{
 					BackupSchedule: "1,16,31,46 0-23 1-31 1-12 0-6",
 					CheckSchedule:  "31 6 * * 1",
@@ -312,10 +328,11 @@ func Test_generateBackupValues(t *testing.T) {
 			name: "test9 - custom backup configuration",
 			args: args{
 				buildValues: &BuildValues{
-					BuildType:       "branch",
-					EnvironmentType: "development",
-					Project:         "example-project",
-					Namespace:       "example-com-main",
+					BuildType:             "branch",
+					EnvironmentType:       "development",
+					Project:               "example-project",
+					Namespace:             "example-com-main",
+					DefaultBackupSchedule: "M H(22-2) * * *",
 				},
 				lYAML: &lagoon.YAML{},
 				mergedVariables: []lagoon.EnvironmentVariable{
@@ -324,10 +341,11 @@ func Test_generateBackupValues(t *testing.T) {
 				},
 			},
 			want: &BuildValues{
-				BuildType:       "branch",
-				EnvironmentType: "development",
-				Project:         "example-project",
-				Namespace:       "example-com-main",
+				BuildType:             "branch",
+				EnvironmentType:       "development",
+				Project:               "example-project",
+				Namespace:             "example-com-main",
+				DefaultBackupSchedule: "M H(22-2) * * *",
 				Backup: BackupConfiguration{
 					S3SecretName: "lagoon-baas-custom-backup-credentials",
 					S3BucketName: "baas-example-project",
@@ -351,10 +369,11 @@ func Test_generateBackupValues(t *testing.T) {
 			name: "test10 - custom backup configuration with endpoint and bucket",
 			args: args{
 				buildValues: &BuildValues{
-					BuildType:       "branch",
-					EnvironmentType: "development",
-					Project:         "example-project",
-					Namespace:       "example-com-main",
+					BuildType:             "branch",
+					EnvironmentType:       "development",
+					Project:               "example-project",
+					Namespace:             "example-com-main",
+					DefaultBackupSchedule: "M H(22-2) * * *",
 				},
 				lYAML: &lagoon.YAML{},
 				mergedVariables: []lagoon.EnvironmentVariable{
@@ -365,10 +384,11 @@ func Test_generateBackupValues(t *testing.T) {
 				},
 			},
 			want: &BuildValues{
-				BuildType:       "branch",
-				EnvironmentType: "development",
-				Project:         "example-project",
-				Namespace:       "example-com-main",
+				BuildType:             "branch",
+				EnvironmentType:       "development",
+				Project:               "example-project",
+				Namespace:             "example-com-main",
+				DefaultBackupSchedule: "M H(22-2) * * *",
 				Backup: BackupConfiguration{
 					S3SecretName: "lagoon-baas-custom-backup-credentials",
 					S3Endpoint:   "https://minio.example.com",
@@ -393,10 +413,11 @@ func Test_generateBackupValues(t *testing.T) {
 			name: "test11 - custom restore configuration",
 			args: args{
 				buildValues: &BuildValues{
-					BuildType:       "branch",
-					EnvironmentType: "development",
-					Project:         "example-project",
-					Namespace:       "example-com-main",
+					BuildType:             "branch",
+					EnvironmentType:       "development",
+					Project:               "example-project",
+					Namespace:             "example-com-main",
+					DefaultBackupSchedule: "M H(22-2) * * *",
 				},
 				lYAML: &lagoon.YAML{},
 				mergedVariables: []lagoon.EnvironmentVariable{
@@ -405,10 +426,11 @@ func Test_generateBackupValues(t *testing.T) {
 				},
 			},
 			want: &BuildValues{
-				BuildType:       "branch",
-				EnvironmentType: "development",
-				Project:         "example-project",
-				Namespace:       "example-com-main",
+				BuildType:             "branch",
+				EnvironmentType:       "development",
+				Project:               "example-project",
+				Namespace:             "example-com-main",
+				DefaultBackupSchedule: "M H(22-2) * * *",
 				Backup: BackupConfiguration{
 					CustomLocation: CustomBackupRestoreLocation{
 						RestoreLocationAccessKey: "abcdefg",
@@ -431,10 +453,11 @@ func Test_generateBackupValues(t *testing.T) {
 			name: "test12 - custom restore and backup configuration with endpoint and bucket",
 			args: args{
 				buildValues: &BuildValues{
-					BuildType:       "branch",
-					EnvironmentType: "development",
-					Project:         "example-project",
-					Namespace:       "example-com-main",
+					BuildType:             "branch",
+					EnvironmentType:       "development",
+					Project:               "example-project",
+					Namespace:             "example-com-main",
+					DefaultBackupSchedule: "M H(22-2) * * *",
 				},
 				lYAML: &lagoon.YAML{},
 				mergedVariables: []lagoon.EnvironmentVariable{
@@ -447,10 +470,11 @@ func Test_generateBackupValues(t *testing.T) {
 				},
 			},
 			want: &BuildValues{
-				BuildType:       "branch",
-				EnvironmentType: "development",
-				Project:         "example-project",
-				Namespace:       "example-com-main",
+				BuildType:             "branch",
+				EnvironmentType:       "development",
+				Project:               "example-project",
+				Namespace:             "example-com-main",
+				DefaultBackupSchedule: "M H(22-2) * * *",
 				Backup: BackupConfiguration{
 					S3SecretName: "lagoon-baas-custom-backup-credentials",
 					S3Endpoint:   "https://minio.example.com",
@@ -477,10 +501,11 @@ func Test_generateBackupValues(t *testing.T) {
 			name: "test13 - K8UP_WEEKLY_RANDOM_FEATURE_FLAG enabled",
 			args: args{
 				buildValues: &BuildValues{
-					BuildType:       "branch",
-					EnvironmentType: "development",
-					Project:         "example-project",
-					Namespace:       "example-com-main",
+					BuildType:             "branch",
+					EnvironmentType:       "development",
+					Project:               "example-project",
+					Namespace:             "example-com-main",
+					DefaultBackupSchedule: "M H(22-2) * * *",
 				},
 				lYAML:           &lagoon.YAML{},
 				mergedVariables: []lagoon.EnvironmentVariable{},
@@ -489,10 +514,11 @@ func Test_generateBackupValues(t *testing.T) {
 				{Name: "K8UP_WEEKLY_RANDOM_FEATURE_FLAG", Value: "enabled"},
 			},
 			want: &BuildValues{
-				BuildType:       "branch",
-				EnvironmentType: "development",
-				Project:         "example-project",
-				Namespace:       "example-com-main",
+				BuildType:             "branch",
+				EnvironmentType:       "development",
+				Project:               "example-project",
+				Namespace:             "example-com-main",
+				DefaultBackupSchedule: "M H(22-2) * * *",
 				Backup: BackupConfiguration{
 					BackupSchedule: "31 1 * * *",
 					CheckSchedule:  "@weekly-random",
@@ -511,10 +537,11 @@ func Test_generateBackupValues(t *testing.T) {
 			name: "test14 - K8UP_WEEKLY_RANDOM_FEATURE_FLAG set but not enabled/valid",
 			args: args{
 				buildValues: &BuildValues{
-					BuildType:       "branch",
-					EnvironmentType: "development",
-					Project:         "example-project",
-					Namespace:       "example-com-main",
+					BuildType:             "branch",
+					EnvironmentType:       "development",
+					Project:               "example-project",
+					Namespace:             "example-com-main",
+					DefaultBackupSchedule: "M H(22-2) * * *",
 				},
 				lYAML:           &lagoon.YAML{},
 				mergedVariables: []lagoon.EnvironmentVariable{},
@@ -523,10 +550,11 @@ func Test_generateBackupValues(t *testing.T) {
 				{Name: "K8UP_WEEKLY_RANDOM_FEATURE_FLAG", Value: "jkhk"},
 			},
 			want: &BuildValues{
-				BuildType:       "branch",
-				EnvironmentType: "development",
-				Project:         "example-project",
-				Namespace:       "example-com-main",
+				BuildType:             "branch",
+				EnvironmentType:       "development",
+				Project:               "example-project",
+				Namespace:             "example-com-main",
+				DefaultBackupSchedule: "M H(22-2) * * *",
 				Backup: BackupConfiguration{
 					BackupSchedule: "31 1 * * *",
 					CheckSchedule:  "31 6 * * 1",
@@ -545,10 +573,11 @@ func Test_generateBackupValues(t *testing.T) {
 			name: "test15 - baas bucket name",
 			args: args{
 				buildValues: &BuildValues{
-					BuildType:       "branch",
-					EnvironmentType: "development",
-					Project:         "example-project",
-					Namespace:       "example-com-main",
+					BuildType:             "branch",
+					EnvironmentType:       "development",
+					Project:               "example-project",
+					Namespace:             "example-com-main",
+					DefaultBackupSchedule: "M H(22-2) * * *",
 				},
 				lYAML: &lagoon.YAML{},
 				mergedVariables: []lagoon.EnvironmentVariable{
@@ -560,10 +589,11 @@ func Test_generateBackupValues(t *testing.T) {
 				},
 			},
 			want: &BuildValues{
-				BuildType:       "branch",
-				EnvironmentType: "development",
-				Project:         "example-project",
-				Namespace:       "example-com-main",
+				BuildType:             "branch",
+				EnvironmentType:       "development",
+				Project:               "example-project",
+				Namespace:             "example-com-main",
+				DefaultBackupSchedule: "M H(22-2) * * *",
 				Backup: BackupConfiguration{
 					BackupSchedule: "31 1 * * *",
 					CheckSchedule:  "31 6 * * 1",
@@ -582,10 +612,11 @@ func Test_generateBackupValues(t *testing.T) {
 			name: "test16 - baas bucket name with shared",
 			args: args{
 				buildValues: &BuildValues{
-					BuildType:       "branch",
-					EnvironmentType: "development",
-					Project:         "example-project",
-					Namespace:       "example-com-main",
+					BuildType:             "branch",
+					EnvironmentType:       "development",
+					Project:               "example-project",
+					Namespace:             "example-com-main",
+					DefaultBackupSchedule: "M H(22-2) * * *",
 				},
 				lYAML: &lagoon.YAML{},
 				mergedVariables: []lagoon.EnvironmentVariable{
@@ -602,10 +633,11 @@ func Test_generateBackupValues(t *testing.T) {
 				},
 			},
 			want: &BuildValues{
-				BuildType:       "branch",
-				EnvironmentType: "development",
-				Project:         "example-project",
-				Namespace:       "example-com-main",
+				BuildType:             "branch",
+				EnvironmentType:       "development",
+				Project:               "example-project",
+				Namespace:             "example-com-main",
+				DefaultBackupSchedule: "M H(22-2) * * *",
 				Backup: BackupConfiguration{
 					BackupSchedule: "31 1 * * *",
 					CheckSchedule:  "31 6 * * 1",
@@ -624,10 +656,11 @@ func Test_generateBackupValues(t *testing.T) {
 			name: "test17 - shared baas bucket name",
 			args: args{
 				buildValues: &BuildValues{
-					BuildType:       "branch",
-					EnvironmentType: "development",
-					Project:         "example-project",
-					Namespace:       "example-com-main",
+					BuildType:             "branch",
+					EnvironmentType:       "development",
+					Project:               "example-project",
+					Namespace:             "example-com-main",
+					DefaultBackupSchedule: "M H(22-2) * * *",
 				},
 				lYAML: &lagoon.YAML{},
 				mergedVariables: []lagoon.EnvironmentVariable{
@@ -639,10 +672,11 @@ func Test_generateBackupValues(t *testing.T) {
 				},
 			},
 			want: &BuildValues{
-				BuildType:       "branch",
-				EnvironmentType: "development",
-				Project:         "example-project",
-				Namespace:       "example-com-main",
+				BuildType:             "branch",
+				EnvironmentType:       "development",
+				Project:               "example-project",
+				Namespace:             "example-com-main",
+				DefaultBackupSchedule: "M H(22-2) * * *",
 				Backup: BackupConfiguration{
 					BackupSchedule: "31 1 * * *",
 					CheckSchedule:  "31 6 * * 1",

--- a/internal/generator/buildvalues.go
+++ b/internal/generator/buildvalues.go
@@ -48,6 +48,7 @@ type BuildValues struct {
 	TaskScaleMaxIterations        int                         `json:"taskScaleMaxIterations"`
 	TaskScaleWaitTime             int                         `json:"taskScaleWaitTime"`
 	ImageCache                    string                      `json:"imageCache"`
+	DefaultBackupSchedule         string                      `json:"defaultBackupSchedule"`
 	DBaaSClient                   *dbaasclient.Client         `json:"-"`
 }
 

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -88,6 +88,8 @@ func NewGenerator(
 	fastlyAPISecretPrefix := helpers.GetEnv("ROUTE_FASTLY_SERVICE_ID", generator.FastlyAPISecretPrefix, generator.Debug)
 	lagoonVersion := helpers.GetEnv("LAGOON_VERSION", generator.LagoonVersion, generator.Debug)
 
+	defaultBackupSchedule := helpers.GetEnv("DEFAULT_BACKUP_SCHEDULE", "M H(22-2) * * *", generator.Debug)
+
 	// try source the namespace from the generator, but whatever is defined in the service account location
 	// should be used if one exists, falls back to whatever came in via generator
 	namespace := helpers.GetEnv("NAMESPACE", generator.Namespace, generator.Debug)
@@ -110,6 +112,8 @@ func NewGenerator(
 
 	//add the dbaas client to build values too
 	buildValues.DBaaSClient = generator.DBaaSClient
+
+	buildValues.DefaultBackupSchedule = defaultBackupSchedule
 
 	// set the task scale iterations/wait times
 	// these are not user modifiable flags, but are injectable by the controller so individual clusters can

--- a/internal/helpers/helpers_cron.go
+++ b/internal/helpers/helpers_cron.go
@@ -114,6 +114,24 @@ func ConvertCrontab(namespace, cron string) (string, error) {
 						continue
 					}
 				}
+				match3, _ := regexp.MatchString("^(H|\\*)/([0-2]?[0-9])$", val)
+				if match3 {
+					// A Minute like H/15 or */15 is defined, create a list of hours with a random start
+					// like 1,7,13,19
+					params := getCaptureBlocks("^(?P<P1>H|\\*)/(?P<P2>[0-2]?[0-9])$", val)
+					step, err := strconv.Atoi(params["P2"])
+					if err != nil {
+						return "", fmt.Errorf("cron definition '%s' is invalid, unable to determine hours value", cron)
+					}
+					counter := int(math.Mod(float64(seed), float64(step)))
+					var hoursArr []string
+					for counter < 24 {
+						hoursArr = append(hoursArr, fmt.Sprintf("%d", counter))
+						counter += step
+					}
+					hours = strings.Join(hoursArr, ",")
+					continue
+				}
 				if isInCSVRange(val, 0, 23) {
 					hours = val
 					continue

--- a/internal/helpers/helpers_cron.go
+++ b/internal/helpers/helpers_cron.go
@@ -114,11 +114,11 @@ func ConvertCrontab(namespace, cron string) (string, error) {
 						continue
 					}
 				}
-				match3, _ := regexp.MatchString("^(H|\\*)/([0-2]?[0-9])$", val)
+				match3, _ := regexp.MatchString("^(H|\\*)/([01]?[0-9]|2[0-3])$", val)
 				if match3 {
-					// A Minute like H/15 or */15 is defined, create a list of hours with a random start
+					// An hour like H/15 or */15 is defined, create a list of hours with a random start
 					// like 1,7,13,19
-					params := getCaptureBlocks("^(?P<P1>H|\\*)/(?P<P2>[0-2]?[0-9])$", val)
+					params := getCaptureBlocks("^(?P<P1>H|\\*)/(?P<P2>[01]?[0-9]|2[0-3])$", val)
 					step, err := strconv.Atoi(params["P2"])
 					if err != nil {
 						return "", fmt.Errorf("cron definition '%s' is invalid, unable to determine hours value", cron)

--- a/internal/helpers/helpers_cron_test.go
+++ b/internal/helpers/helpers_cron_test.go
@@ -149,7 +149,7 @@ func TestConvertCrontab(t *testing.T) {
 				namespace: "example-com-main",
 				cron:      "M */6 * * *",
 			},
-			want: "31 1,7,13,19",
+			want: "31 1,7,13,19 * * *",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/helpers/helpers_cron_test.go
+++ b/internal/helpers/helpers_cron_test.go
@@ -128,7 +128,7 @@ func TestConvertCrontab(t *testing.T) {
 			want: "1,16,31,46 23 * * 0-5",
 		},
 		{
-			name: "test14 - set day",
+			name: "test15 - set day",
 			args: args{
 				namespace: "example-com-main",
 				cron:      "M/15 * 31 * 0-5",
@@ -136,12 +136,20 @@ func TestConvertCrontab(t *testing.T) {
 			want: "1,16,31,46 * 31 * 0-5",
 		},
 		{
-			name: "test14 - set month",
+			name: "test16 - set month",
 			args: args{
 				namespace: "example-com-main",
 				cron:      "M/15 * * 11 0-5",
 			},
 			want: "1,16,31,46 * * 11 0-5",
+		},
+		{
+			name: "test17 - hourly interval",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "M */6 * * *",
+			},
+			want: "31 1,7,13,19",
 		},
 	}
 	for _, tt := range tests {

--- a/test-resources/template-backups/test7-results/k8up-lagoon-backup-schedule.yaml
+++ b/test-resources/template-backups/test7-results/k8up-lagoon-backup-schedule.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: backup.appuio.ch/v1alpha1
+kind: Schedule
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: k8up-lagoon-backup-schedule
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: k8up-schedule
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: k8up-lagoon-backup-schedule
+    lagoon.sh/service-type: k8up-schedule
+    lagoon.sh/template: k8up-schedule-0.1.0
+  name: k8up-lagoon-backup-schedule
+spec:
+  backend:
+    repoPasswordSecretRef:
+      key: repo-pw
+      name: baas-repo-pw
+    s3:
+      bucket: baas-example-project
+  backup:
+    resources: {}
+    schedule: 48 0,6,12,18 * * *
+  check:
+    resources: {}
+    schedule: 48 5 * * 1
+  prune:
+    resources: {}
+    retention:
+      keepDaily: 7
+      keepMonthly: 1
+      keepWeekly: 6
+    schedule: 48 3 * * 0
+  resourceRequirementsTemplate: {}
+status: {}

--- a/test-resources/template-backups/test7/docker-compose.yml
+++ b/test-resources/template-backups/test7/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '2'
+services:
+  node:
+    networks:
+      - amazeeio-network
+      - default
+    build:
+      context: .
+      dockerfile: node.dockerfile
+    labels:
+      lagoon.type: node
+    volumes:
+      - .:/app:delegated
+    environment:
+      - LAGOON_LOCALDEV_HTTP_PORT=3000
+      - LAGOON_ROUTE=http://node.docker.amazee.io
+
+networks:
+  amazeeio-network:
+    external: true

--- a/test-resources/template-backups/test7/lagoon.yml
+++ b/test-resources/template-backups/test7/lagoon.yml
@@ -1,0 +1,10 @@
+docker-compose-yaml: ../test-resources/template-backups/test7/docker-compose.yml
+
+environment_variables:
+  git_sha: "true"
+
+environments:
+  main:
+    routes:
+      - node:
+          - example.com


### PR DESCRIPTION
Minor adjustment to the cron generator to account for interval based hourly times (H/6 or */6, etc) and to correctly consume the `DEFAULT_BACKUP_SCHEDULE` variable from remote-controller injected variable