### PR TITLE
refactor: make warning message clearer for route cleanup

### DIFF
--- a/legacy/build-deploy-docker-compose.sh
+++ b/legacy/build-deploy-docker-compose.sh
@@ -1297,9 +1297,16 @@ if [ ${#DELETE_INGRESS[@]} -ne 0 ]; then
   CLEANUP_WARNINGS="true"
   ((++BUILD_WARNING_COUNT))
   echo ">> Lagoon detected routes that have been removed from the .lagoon.yml or Lagoon API"
+  echo "> If you need these routes, you should update your .lagoon.yml file and make sure the routes exist."
   if [ "$(featureFlag CLEANUP_REMOVED_LAGOON_ROUTES)" != enabled ]; then
-    echo "> You can remove these in the next build by setting the flag 'LAGOON_FEATURE_FLAG_CLEANUP_REMOVED_LAGOON_ROUTES=enabled' as a GLOBAL scoped variable to this environment or project"
+    echo "> If you no longer need these routes, you can instruct Lagoon to remove it from the environment by setting the following variable"
+    echo "> 'LAGOON_FEATURE_FLAG_CLEANUP_REMOVED_LAGOON_ROUTES=enabled' as a GLOBAL scoped variable to this environment or project"
+    echo "> You should remove this variable after the deployment has been completed, otherwise future route removals will happen automatically"
+  else
+    echo "> 'LAGOON_FEATURE_FLAG_CLEANUP_REMOVED_LAGOON_ROUTES=enabled' is configured and the following routes will be removed."
+    echo "> You should remove this variable if you don't want routes to be removed automatically"
   fi
+  echo "> Futurue releases of Lagoon may remove routes automatically, you should ensure that your routes are up always up to date if you see this warning"
   for DI in ${DELETE_INGRESS[@]}
   do
     if [ "$(featureFlag CLEANUP_REMOVED_LAGOON_ROUTES)" = enabled ]; then


### PR DESCRIPTION
Just a quick one to make the warning message when a route cleanup detection event is encountered.

This hopefully makes it clear if a user has configured the route cleanup feature flag and its usage, that route cleanup may be automatic in the future, and that the user can correct the issue themselves if they need to by either fixing their lagoon.yml or adding the clean up variable.

Now the user will see one of two warnings, if they have routes that can be cleaned up
```
>> Lagoon detected routes that have been removed from the .lagoon.yml or Lagoon API
> If you need these routes, you should update your .lagoon.yml file and make sure the routes exist.
> You can remove these in the next build by setting the flag 'LAGOON_FEATURE_FLAG_CLEANUP_REMOVED_LAGOON_ROUTES=enabled' as a GLOBAL scoped variable to this environment or project
> If you no longer need these routes, you can instruct Lagoon to remove it from the environment by setting the following variable
> 'LAGOON_FEATURE_FLAG_CLEANUP_REMOVED_LAGOON_ROUTES=enabled' as a GLOBAL scoped variable to this environment or project
> You should remove this variable after the deployment has been completed, otherwise future route removals will happen automatically
> Futurue releases of Lagoon may remove routes automatically, you should ensure that your routes are up always up to date if you see this warning
```
or if the variable is set and the route have been cleaned up (and how to disable the feature afterwards if they want to)
```
>> Lagoon detected routes that have been removed from the .lagoon.yml or Lagoon API
> If you need these routes, you should update your .lagoon.yml file and make sure the routes exist.
> 'LAGOON_FEATURE_FLAG_CLEANUP_REMOVED_LAGOON_ROUTES=enabled' is configured and the following routes will be removed.
> You should remove this variable if you don't want routes to be removed automatically
> Futurue releases of Lagoon may remove routes automatically, you should ensure that your routes are up always up to date if you see this warning
```

This means that this warning will always show whenever there is an action to perform, or if an action has been performed, so the user can see when it occured.