### PR TITLE
Replace grype with trivy for cyclonedx generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,9 +111,6 @@ RUN curl -sSL https://github.com/uselagoon/lagoon-linter/releases/download/v0.8.
 #     | tar -xz -C /usr/local/bin build-deploy-tool
 COPY --from=golang /app/build-deploy-tool /usr/local/bin/build-deploy-tool
 
-RUN curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin > /dev/null 2>&1
-#curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin > /dev/null 2>&1
-
 # enable running unprivileged
 RUN fix-permissions /home && fix-permissions /kubectl-build-deploy
 

--- a/legacy/scripts/exec-generate-insights-configmap.sh
+++ b/legacy/scripts/exec-generate-insights-configmap.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 TMP_DIR="${TMP_DIR:-/tmp}"
-#SBOM_OUTPUT="cyclonedx-json" -- This is the syft format
-# We're moving to trivy
 SBOM_OUTPUT="cyclonedx"
 
 SBOM_OUTPUT_FILE="${TMP_DIR}/${IMAGE_NAME}.cyclonedx.json.gz"
@@ -45,10 +43,9 @@ processImageInspect() {
 
 processImageInspect
 
-echo "Running sbom scan using syft"
+echo "Running sbom scan using trivy"
 echo "Image being scanned: ${IMAGE_FULL}"
 
-#DOCKER_HOST=docker-host.lagoon.svc docker run --rm -v /var/run/docker.sock:/var/run/docker.sock imagecache.amazeeio.cloud/anchore/syft packages ${IMAGE_FULL} --quiet -o ${SBOM_OUTPUT} | gzip > ${SBOM_OUTPUT_FILE}
 DOCKER_HOST=docker-host.lagoon.svc docker run --rm -v /var/run/docker.sock:/var/run/docker.sock imagecache.amazeeio.cloud/aquasec/trivy image ${IMAGE_FULL} --format ${SBOM_OUTPUT} | gzip > ${SBOM_OUTPUT_FILE}
 
 FILESIZE=$(stat -c%s "$SBOM_OUTPUT_FILE")

--- a/legacy/scripts/exec-generate-insights-configmap.sh
+++ b/legacy/scripts/exec-generate-insights-configmap.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 TMP_DIR="${TMP_DIR:-/tmp}"
-SBOM_OUTPUT="cyclonedx-json"
+#SBOM_OUTPUT="cyclonedx-json" -- This is the syft format
+# We're moving to trivy
+SBOM_OUTPUT="cyclonedx"
+
 SBOM_OUTPUT_FILE="${TMP_DIR}/${IMAGE_NAME}.cyclonedx.json.gz"
 SBOM_CONFIGMAP="lagoon-insights-sbom-${IMAGE_NAME}"
 IMAGE_INSPECT_CONFIGMAP="lagoon-insights-image-${IMAGE_NAME}"
@@ -45,7 +48,8 @@ processImageInspect
 echo "Running sbom scan using syft"
 echo "Image being scanned: ${IMAGE_FULL}"
 
-DOCKER_HOST=docker-host.lagoon.svc docker run --rm -v /var/run/docker.sock:/var/run/docker.sock imagecache.amazeeio.cloud/anchore/syft packages ${IMAGE_FULL} --quiet -o ${SBOM_OUTPUT} | gzip > ${SBOM_OUTPUT_FILE}
+#DOCKER_HOST=docker-host.lagoon.svc docker run --rm -v /var/run/docker.sock:/var/run/docker.sock imagecache.amazeeio.cloud/anchore/syft packages ${IMAGE_FULL} --quiet -o ${SBOM_OUTPUT} | gzip > ${SBOM_OUTPUT_FILE}
+DOCKER_HOST=docker-host.lagoon.svc docker run --rm -v /var/run/docker.sock:/var/run/docker.sock imagecache.amazeeio.cloud/aquasec/trivy image ${IMAGE_FULL} --format ${SBOM_OUTPUT} | gzip > ${SBOM_OUTPUT_FILE}
 
 FILESIZE=$(stat -c%s "$SBOM_OUTPUT_FILE")
 echo "Size of ${SBOM_OUTPUT_FILE} = $FILESIZE bytes."


### PR DESCRIPTION
As it stands, we're using trivy as the sbom scanner in insights-handler, but generating sboms with `syft` on the remote side.

This has lead to issues with format incompatibilities across the two tools - specifically, an [update to the cyclonedx format ](https://github.com/CycloneDX/cyclonedx-go/releases/tag/v0.8.0) wasn't tracked in both tools and lead to a [fatal crash](https://github.com/uselagoon/insights-handler/pull/60)  in the handler.

This brings the insights generation in line, tooling wise, by replacing grype with trivy for sbom generation.