### PR TITLE
fix: remove the secret when tls-acme is set to false

### DIFF
--- a/legacy/build-deploy-docker-compose.sh
+++ b/legacy/build-deploy-docker-compose.sh
@@ -1931,8 +1931,9 @@ TLS_FALSE_INGRESSES=$(kubectl -n ${NAMESPACE} get ingress -o json | jq -r '.item
 for TLS_FALSE_INGRESS in $TLS_FALSE_INGRESSES; do
   TLS_SECRETS=$(kubectl -n ${NAMESPACE} get ingress ${TLS_FALSE_INGRESS} -o json | jq -r '.spec.tls[]?.secretName')
   for TLS_SECRET in $TLS_SECRETS; do
+    echo ">> Cleaning up certificate for ${TLS_SECRET} as tls-acme is set to false"
+    kubectl -n ${NAMESPACE} delete secret ${TLS_SECRET}-tls
     if kubectl -n ${NAMESPACE} get certificates.cert-manager.io ${TLS_SECRET} &> /dev/null; then
-      echo ">> Cleaning up certificate for ${TLS_SECRET} as tls-acme is set to false"
       kubectl -n ${NAMESPACE} delete certificates.cert-manager.io ${TLS_SECRET}
     fi
   done


### PR DESCRIPTION
In combination with https://github.com/uselagoon/lagoon/pull/3638, this fixes the behaviour of when `tls-acme: true` is changed to `false` so that it also correctly cleans up the certificate being served.

closes #290 