### PR TITLE
Adds ability to control insights scan image with env vars

### DIFF
--- a/legacy/scripts/exec-generate-insights-configmap.sh
+++ b/legacy/scripts/exec-generate-insights-configmap.sh
@@ -8,7 +8,7 @@ SBOM_CONFIGMAP="lagoon-insights-sbom-${IMAGE_NAME}"
 IMAGE_INSPECT_CONFIGMAP="lagoon-insights-image-${IMAGE_NAME}"
 IMAGE_INSPECT_OUTPUT_FILE="${TMP_DIR}/${IMAGE_NAME}.image-inspect.json.gz"
 
-# Here we give the user the ability to override the insights scan image
+# Here we give the cluster administrator the ability to override the insights scan image
 INSIGHTS_SCAN_IMAGE="aquasec/trivy"
   if [ "$ADMIN_LAGOON_FEATURE_FLAG_INSIGHTS_SCAN_IMAGE" ]; then
     INSIGHTS_SCAN_IMAGE="${ADMIN_LAGOON_FEATURE_FLAG_INSIGHTS_SCAN_IMAGE}"

--- a/legacy/scripts/exec-generate-insights-configmap.sh
+++ b/legacy/scripts/exec-generate-insights-configmap.sh
@@ -8,6 +8,9 @@ SBOM_CONFIGMAP="lagoon-insights-sbom-${IMAGE_NAME}"
 IMAGE_INSPECT_CONFIGMAP="lagoon-insights-image-${IMAGE_NAME}"
 IMAGE_INSPECT_OUTPUT_FILE="${TMP_DIR}/${IMAGE_NAME}.image-inspect.json.gz"
 
+# Here we give the user the ability to override the insights scan image
+INSIGHTS_SCAN_IMAGE="${INSIGHTS_SCAN_IMAGE:-aquasec/trivy}"
+
 set +x
 echo "Running image inspect on: ${IMAGE_FULL}"
 
@@ -45,8 +48,9 @@ processImageInspect
 
 echo "Running sbom scan using trivy"
 echo "Image being scanned: ${IMAGE_FULL}"
+echo "Using image for scan ${IMAGECACHE_REGISTRY}${INSIGHTS_SCAN_IMAGE}"
 
-DOCKER_HOST=docker-host.lagoon.svc docker run --rm -v /var/run/docker.sock:/var/run/docker.sock imagecache.amazeeio.cloud/aquasec/trivy image ${IMAGE_FULL} --format ${SBOM_OUTPUT} | gzip > ${SBOM_OUTPUT_FILE}
+DOCKER_HOST=docker-host.lagoon.svc docker run --rm -v /var/run/docker.sock:/var/run/docker.sock ${IMAGECACHE_REGISTRY}${INSIGHTS_SCAN_IMAGE} image ${IMAGE_FULL} --format ${SBOM_OUTPUT} | gzip > ${SBOM_OUTPUT_FILE}
 
 FILESIZE=$(stat -c%s "$SBOM_OUTPUT_FILE")
 echo "Size of ${SBOM_OUTPUT_FILE} = $FILESIZE bytes."

--- a/legacy/scripts/exec-generate-insights-configmap.sh
+++ b/legacy/scripts/exec-generate-insights-configmap.sh
@@ -9,7 +9,10 @@ IMAGE_INSPECT_CONFIGMAP="lagoon-insights-image-${IMAGE_NAME}"
 IMAGE_INSPECT_OUTPUT_FILE="${TMP_DIR}/${IMAGE_NAME}.image-inspect.json.gz"
 
 # Here we give the user the ability to override the insights scan image
-INSIGHTS_SCAN_IMAGE="${INSIGHTS_SCAN_IMAGE:-aquasec/trivy}"
+INSIGHTS_SCAN_IMAGE="aquasec/trivy"
+  if [ "$ADMIN_LAGOON_FEATURE_FLAG_INSIGHTS_SCAN_IMAGE" ]; then
+    INSIGHTS_SCAN_IMAGE="${ADMIN_LAGOON_FEATURE_FLAG_INSIGHTS_SCAN_IMAGE}"
+  fi
 
 set +x
 echo "Running image inspect on: ${IMAGE_FULL}"


### PR DESCRIPTION
Currently the insights image is fixed in the `exec-generate-insights-configmap.sh` file - this PR:

- makes use of the globally set IMAGECACHE_REGISTRY env var to set an image cache
- introduces INSIGHTS_SCAN_IMAGE env var to allow overriding of the image used to run the scan