### PR TITLE
fix: postgres-single backup command use correct variables

### DIFF
--- a/legacy/helmcharts/postgres-single/templates/deployment.yaml
+++ b/legacy/helmcharts/postgres-single/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{- end }}
       annotations:
         {{- include "postgres-single.annotations" . | nindent 8 }}
-        k8up.syn.tools/backupcommand: /bin/sh -c "PGPASSWORD=${{ regexReplaceAll "\\W+" .Release.Name "_" | upper }}_PASSWORD pg_dump --host=localhost --port=${{ regexReplaceAll "\\W+" .Release.Name "_" | upper }}_SERVICE_PORT --dbname=${{ regexReplaceAll "\\W+" .Release.Name "_" | upper }}_DB --username=${{ regexReplaceAll "\\W+" .Release.Name "_" | upper }}_USER --format=t -w"
+        k8up.syn.tools/backupcommand: /bin/sh -c "PGPASSWORD=$POSTGRES_PASSWORD pg_dump --host=localhost --port=${{ regexReplaceAll "\\W+" .Release.Name "_" | upper }}_SERVICE_PORT --dbname=$POSTGRES_DB --username=$POSTGRES_USER --format=t -w"
         k8up.syn.tools/file-extension: .{{ include "postgres-single.fullname" . }}.tar
         lagoon.sh/configMapSha: {{ .Values.configMapSha | quote }}
     spec:


### PR DESCRIPTION
Just a quick fix identified through general testing.

The previous backup command for `postgres-single` used a username and password derived from the service name, which is not correct. Only the port can be derived this way due to `enableServiceLinks` which creates the port from the service name. The other variables are defined within the lagoon provided base images.