### PR TITLE
refactor: use new insights.lagoon.sh/type label

### DIFF
--- a/legacy/scripts/exec-generate-insights-configmap.sh
+++ b/legacy/scripts/exec-generate-insights-configmap.sh
@@ -44,7 +44,8 @@ processImageInspect() {
       lagoon.sh/buildName=${LAGOON_BUILD_NAME} \
       lagoon.sh/project=${PROJECT} \
       lagoon.sh/environment=${ENVIRONMENT} \
-      lagoon.sh/service=${IMAGE_NAME}
+      lagoon.sh/service=${IMAGE_NAME} \
+      insights.lagoon.sh/type=inspect
 }
 
 processImageInspect
@@ -88,7 +89,8 @@ processSbom() {
         lagoon.sh/buildName=${LAGOON_BUILD_NAME} \
         lagoon.sh/project=${PROJECT} \
         lagoon.sh/environment=${ENVIRONMENT} \
-        lagoon.sh/service=${IMAGE_NAME}
+        lagoon.sh/service=${IMAGE_NAME} \
+        insights.lagoon.sh/type=sbom
   fi
 }
 


### PR DESCRIPTION
This adds an explicit label used for typing insights ConfigMap data.

It essentially duplicates the data that is currently in the `lagoon.sh/insightsType` label, but brings it in line with [this proposal](https://github.com/uselagoon/lagoon/issues/3597).

Furthermore, by dropping the `-gz` designation in the type, we are pointing towards the proposed introduction of [stricter types for insights-remote](https://github.com/uselagoon/insights-remote/issues/19). With regards to this, note how the new `insights.lagoon.sh/type` does not reference whether the data is compressed or not - this acknowledges that we will only process compressed binary data for `sbom` and `inspect` types going forward.