### PR TITLE
refactor: dbaas meta service check

### DIFF
--- a/cmd/template_dbaas_test.go
+++ b/cmd/template_dbaas_test.go
@@ -87,6 +87,21 @@ func TestDBaaSTemplateGeneration(t *testing.T) {
 			templatePath: "testdata/output",
 			want:         "../internal/testdata/node/dbaas-templates/dbaas-2",
 		},
+		{
+			name: "test6 - postgres",
+			args: testdata.GetSeedData(
+				testdata.TestData{
+					ProjectName:     "example-project",
+					EnvironmentName: "main",
+					Branch:          "main",
+					LagoonYAML:      "../internal/testdata/complex/lagoon.services.yml",
+					ProjectVariables: []lagoon.EnvironmentVariable{
+						{Name: "LAGOON_DBAAS_ENVIRONMENT_TYPES", Value: "postgres-15:production-postgres,mongo-4:production-mongo", Scope: "build"},
+					},
+				}, true),
+			templatePath: "testdata/output",
+			want:         "../internal/testdata/complex/dbaas-templates/dbaas-4",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/testdata/complex/dbaas-templates/dbaas-4/dbaas.yaml
+++ b/internal/testdata/complex/dbaas-templates/dbaas-4/dbaas.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: mariadb.amazee.io/v1
+kind: MariaDBConsumer
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: mariadb-10-11
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: mariadb-dbaas
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: mariadb-10-11
+    lagoon.sh/service-type: mariadb-dbaas
+    lagoon.sh/template: mariadb-dbaas-0.1.0
+  name: mariadb-10-11
+spec:
+  consumer:
+    services: {}
+  environment: production
+  provider: {}
+status: {}

--- a/internal/testdata/complex/docker-compose.services.yml
+++ b/internal/testdata/complex/docker-compose.services.yml
@@ -1,0 +1,116 @@
+version: '2'
+
+volumes:
+  solr-7-data:
+  solr-8-data:
+  opensearch-2-data:
+  scratch:
+
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    labels:
+      lagoon.type: basic-persistent
+      lagoon.persistent: /app/files
+      lagoon.persistent.size: 10Mi
+      lagoon.persistent.class: bulk
+    ports:
+      - '3000:3000'
+    container_name: go-web
+    environment:
+      - LAGOON_TEST_VAR=internal-services-test
+      - LAGOON_GIT_SHA=SHA256
+      - LAGOON_ENVIRONMENT_TYPE=development
+      - STORAGE_LOCATION=/app/files
+    volumes:
+      - scratch:/app/files
+
+  mariadb-10-5:
+    image: uselagoon/mariadb-10.5:latest
+    labels:
+      lagoon.type: mariadb-single
+      lagoon.persistent.size: 100Mi
+    ports:
+      - '3306'
+
+  mariadb-10-11:
+    image: uselagoon/mariadb-10.11:latest
+    labels:
+      lagoon.type: mariadb
+    ports:
+      - '3306'
+
+  postgres-11:
+    image: uselagoon/postgres-11:latest
+    labels:
+      lagoon.type: postgres-single
+      lagoon.persistent.size: 100Mi
+    ports:
+      - '5432'
+
+  postgres-15:
+    image: uselagoon/postgres-15:latest
+    labels:
+      lagoon.type: postgres
+    ports:
+      - '5432'
+
+  opensearch-2:
+    image: uselagoon/opensearch-2:latest
+    environment:
+    - cluster.name=opensearch-cluster
+    - node.name=opensearch-2
+    - discovery.seed_hosts=opensearch-2
+    - cluster.initial_cluster_manager_nodes=opensearch-2
+    - bootstrap.memory_lock=true
+    - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    volumes:
+      - opensearch-2-data:/usr/share/opensearch/data
+    labels:
+      lagoon.type: opensearch
+      lagoon.persistent.size: 100Mi
+    ports:
+      - '9200'
+
+  mongo-4:
+    image: uselagoon/mongo-4:latest
+    labels:
+      lagoon.type: mongo
+    ports:
+      - '27017'
+
+  redis-6:
+    image: uselagoon/redis-5:latest
+    labels:
+      lagoon.type: redis
+    ports:
+      - '6379'
+
+  redis-7:
+    image: uselagoon/redis-6:latest
+    labels:
+      lagoon.type: redis
+    ports:
+      - '6379'
+
+  solr-8:
+    image: uselagoon/solr-8:latest
+    labels:
+      lagoon.type: solr
+      lagoon.persistent.size: 100Mi
+    ports:
+     - "8983"
+    volumes:
+      - solr-8-data:/var/solr
+    command:
+      - solr-precreate
+      - mycore

--- a/internal/testdata/complex/lagoon.services.yml
+++ b/internal/testdata/complex/lagoon.services.yml
@@ -1,0 +1,5 @@
+---
+docker-compose-yaml: ../internal/testdata/complex/docker-compose.services.yml
+
+environment_variables:
+  git_sha: 'true'


### PR DESCRIPTION
Just refactoring the meta service check for when just `mariadb`, `postgres`, or `mongo` are requested.
The move to go in #115 didn't fully convert the meta checks as some things still take place in BASH for generating the `-single` versions of these types.