### PR TITLE
chore: lower timeout to 1.5hr for redis-persist backup

### DIFF
--- a/legacy/helmcharts/redis-persistent/templates/deployment.yaml
+++ b/legacy/helmcharts/redis-persistent/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         {{- end }}
       annotations:
         {{- include "redis-persistent.annotations" . | nindent 8 }}
-        k8up.syn.tools/backupcommand: /bin/sh -c "timeout 14400 /bin/busybox tar -cf - -C {{ .Values.persistentStorage.path }} ."
+        k8up.syn.tools/backupcommand: /bin/sh -c "timeout 5400 tar -cf - -C {{ .Values.persistentStorage.path }} ."
         k8up.syn.tools/file-extension: .{{ include "redis-persistent.fullname" . }}.tar
         lagoon.sh/configMapSha: {{ .Values.configMapSha | quote }}
     spec:


### PR DESCRIPTION
#314 set the timeout to 14400 (4hrs) but this may be too long

This lowers it to 1.5hrs. Acknowledging this is pretty hacky solution generally. But if a redis-persistent is taking longer than this to backup, you probably shouldn't be using redis-persistent in a pod.