### PR TITLE
fix: use jq base64d and remove errant s in cert cleanup

### DIFF
--- a/legacy/build-deploy-docker-compose.sh
+++ b/legacy/build-deploy-docker-compose.sh
@@ -1874,7 +1874,7 @@ for TLS_FALSE_INGRESS in $TLS_FALSE_INGRESSES; do
   for TLS_SECRET in $TLS_SECRETS; do
     echo ">> Cleaning up certificate for ${TLS_SECRET} as tls-acme is set to false"
     # check if it is a lets encrypt certificate
-    if openssl x509 -in <(kubectl -n ${NAMESPACE} get secret ${TLS_SECRET}-tls -o json | jq -r '.data."tls.crt"' | base64 --decode) -text -noout | grep -o -q "Let's Encrypt" s &> /dev/null; then
+    if openssl x509 -in <(kubectl -n ${NAMESPACE} get secret ${TLS_SECRET}-tls -o json | jq -r '.data."tls.crt" | @base64d') -text -noout | grep -o -q "Let's Encrypt" &> /dev/null; then
       kubectl -n ${NAMESPACE} delete secret ${TLS_SECRET}-tls
     fi
     if kubectl -n ${NAMESPACE} get certificates.cert-manager.io ${TLS_SECRET} &> /dev/null; then


### PR DESCRIPTION
In cases where `tls-acme` is changed from true to false, and a certificate cleanup is required, the step that would check the certificate to see if it was a Let's Encrypt certificate would fail due to the following base64 decode error inside a build pod.

```
>> Cleaning up certificate for example.com-tls as tls-acme is set to false
base64: unrecognized option: decode
```

Initially introduced in #291, this changes the base64 decode to use the one built into JQ like other commands in the bash script do. Also removes an errant `s` in the grep.