### PR TITLE
fix: tls-acme stale challenge check to not use busybox date

### DIFF
--- a/legacy/build-deploy-docker-compose.sh
+++ b/legacy/build-deploy-docker-compose.sh
@@ -1194,9 +1194,7 @@ patchBuildStep "${buildStartTime}" "${previousStepEnd}" "${currentStepEnd}" "${N
 ### Report any ingress that have stale or stalled acme challenges, this accordion will only show if there are stale challenges
 ##############################################s
 # collect any current challenge routes in the namespace that are older than 1 hour (to ignore current build ones or pending ones)
-CURRENT_CHALLENGE_ROUTES=$(kubectl -n ${NAMESPACE} get ingress -l "acme.cert-manager.io/http01-solver=true" -o jsonpath='{range .items[*]}{.spec.rules[0].host} {.metadata.creationTimestamp}{"\n"}{end}' | while read -r name timestamp; do
-        echo "$name" | awk -v current_time=$(date +%s) -v hours_back=$(date +%s -d "1 hour ago") -v ns_time=$(date --date="${timestamp}" +%s) '(current_time - ns_time) >(current_time - hours_back){print $0}';
-done)
+CURRENT_CHALLENGE_ROUTES=$(kubectl -n ${NAMESPACE} get ingress -l "acme.cert-manager.io/http01-solver=true" 2> /dev/null | awk 'match($7,/[0-9]+d|[0-9]+h|[0-9][0-9][0-9]m|[6-9][0-9]m/) {print $1}')
 if [ "${CURRENT_CHALLENGE_ROUTES[@]}" != "" ]; then
   previousStepEnd=${currentStepEnd}
   beginBuildStep "Route/Ingress Certificate Challenges" "staleChallenges"


### PR DESCRIPTION
Just a small fix to a date check since date in busybox is limited. Replaces it with awk to regex anything greater than 60m/1h instead.

Currently when this process runs, it results in this in the output which can be confusing to users.
```
date: invalid date '1 hour ago'
date: invalid date '2024-05-27T08:53:43Z'
```

This fix also nullifies error output if there are no ingress in the namespace (which is the case majority of the time)