### PR TITLE
fix: use yq for checking container-registries because shyaml is not great

### DIFF
--- a/legacy/build-deploy.sh
+++ b/legacy/build-deploy.sh
@@ -213,19 +213,19 @@ do
   echo "> Checking details for ${PRIVATE_CONTAINER_REGISTRY}"
   PRIVATE_CONTAINER_REGISTRY_SAFE=$(echo ${PRIVATE_CONTAINER_REGISTRY} | tr '[:lower:]' '[:upper:]' | tr '-' '_')
   # check if a url is set, if none set proceed against docker hub
-  PRIVATE_CONTAINER_REGISTRY_URL=$(cat .lagoon.yml | shyaml get-value container-registries.$PRIVATE_CONTAINER_REGISTRY.url 2>/dev/null)
-
-  if [ -z $PRIVATE_CONTAINER_REGISTRY_URL ]; then
+  PRIVATE_CONTAINER_REGISTRY_URL=$(yq e '.container-registries.'$PRIVATE_CONTAINER_REGISTRY'.url' .lagoon.yml)
+  if [ "$PRIVATE_CONTAINER_REGISTRY_URL" == "null" ]; then
     echo "No 'url' defined for registry $PRIVATE_CONTAINER_REGISTRY, will proceed against docker hub";
+    PRIVATE_CONTAINER_REGISTRY_URL=""
   fi
   # check the username and passwords are defined in yaml
   PRIVATE_CONTAINER_REGISTRY_USERNAME=""
-  PRIVATE_CONTAINER_REGISTRY_USERNAME=$(cat .lagoon.yml | shyaml get-value container-registries.$PRIVATE_CONTAINER_REGISTRY.username 2>/dev/null)
+  PRIVATE_CONTAINER_REGISTRY_USERNAME=$(yq e '.container-registries.'$PRIVATE_CONTAINER_REGISTRY'.username' .lagoon.yml)
   
   PRIVATE_CONTAINER_REGISTRY_CREDENTIAL_USERNAME=""
   getRegistryUsernameFromEnvironmentVariables
 
-  if [ -z $PRIVATE_CONTAINER_REGISTRY_USERNAME ] && [ -z $PRIVATE_CONTAINER_REGISTRY_CREDENTIAL_USERNAME ]; then
+  if [ "$PRIVATE_CONTAINER_REGISTRY_USERNAME" == "null" ] && [ -z $PRIVATE_CONTAINER_REGISTRY_CREDENTIAL_USERNAME ]; then
     echo "No 'username' defined for registry $PRIVATE_CONTAINER_REGISTRY"; exit 1;
   fi
   if [ -z $PRIVATE_CONTAINER_REGISTRY_CREDENTIAL_USERNAME ]; then
@@ -234,11 +234,11 @@ do
     PRIVATE_CONTAINER_REGISTRY_USERNAME_SOURCE=".lagoon.yml"
   fi
   PRIVATE_CONTAINER_REGISTRY_PASSWORD=""
-  PRIVATE_CONTAINER_REGISTRY_PASSWORD=$(cat .lagoon.yml | shyaml get-value container-registries.$PRIVATE_CONTAINER_REGISTRY.password 2>/dev/null)
+  PRIVATE_CONTAINER_REGISTRY_PASSWORD=$(yq e '.container-registries.'$PRIVATE_CONTAINER_REGISTRY'.password' .lagoon.yml)
   PRIVATE_REGISTRY_CREDENTIAL=""
   getRegistryPasswordFromEnvironmentVariables
 
-  if [ -z $PRIVATE_CONTAINER_REGISTRY_PASSWORD ] && [ -z $PRIVATE_REGISTRY_CREDENTIAL ]; then
+  if [ "$PRIVATE_CONTAINER_REGISTRY_PASSWORD" == "null" ] && [ -z $PRIVATE_REGISTRY_CREDENTIAL ]; then
     echo "No 'password' defined for registry $PRIVATE_CONTAINER_REGISTRY"; exit 1;
   fi
   # if we have everything we need, we can proceed to logging in


### PR DESCRIPTION
shyaml is not great and we should stop using it. As more and more work goes into #289 the usage of shyaml is reduced significantly though.

This changes the checks to use `yq` where possible in the container-registry functions to handle things shyaml isn't great with.

The version of `yq` used is `v4.35.2` which is what is used in the build-deploy-image currently

With updated [gist](https://gist.github.com/shreddedbacon/25ee93cc4bee89e4510ae0173892eb3d) 

#310 introduced the changed logic, but the version of shyaml differs across operating systems and some handled it differently.