### PR TITLE
chore: increase max-allowed-packet in mysql backup cmds

### DIFF
--- a/internal/templating/backups/template_prebackuppod.go
+++ b/internal/templating/backups/template_prebackuppod.go
@@ -280,7 +280,7 @@ var preBackupPodSpecs = PreBackupPods{
   BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1);
   fi &&
   dump=$(mktemp)
-  && mysqldump --max-allowed-packet=500M --events --routines --quick
+  && mysqldump --max-allowed-packet=1G --events --routines --quick
   --add-locks --no-autocommit --single-transaction --no-create-db
   --no-data --no-tablespaces
   -h $BACKUP_DB_HOST
@@ -288,7 +288,7 @@ var preBackupPodSpecs = PreBackupPods{
   -p$BACKUP_DB_PASSWORD
   $BACKUP_DB_DATABASE
   > $dump
-  && mysqldump --max-allowed-packet=500M --events --routines --quick
+  && mysqldump --max-allowed-packet=1G --events --routines --quick
   --add-locks --no-autocommit --single-transaction --no-create-db
   --ignore-table=$BACKUP_DB_DATABASE.watchdog
   --no-create-info --no-tablespaces --skip-triggers

--- a/internal/templating/backups/test-resources/result-prebackuppod1.yaml
+++ b/internal/templating/backups/test-resources/result-prebackuppod1.yaml
@@ -20,7 +20,7 @@ metadata:
   name: mariadb-database-prebackuppod
 spec:
   backupCommand: |
-    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1); fi && dump=$(mktemp) && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --no-data --no-tablespaces -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE > $dump && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --ignore-table=$BACKUP_DB_DATABASE.watchdog --no-create-info --no-tablespaces --skip-triggers -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE >> $dump && cat $dump && rm $dump"
+    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1); fi && dump=$(mktemp) && mysqldump --max-allowed-packet=1G --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --no-data --no-tablespaces -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE > $dump && mysqldump --max-allowed-packet=1G --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --ignore-table=$BACKUP_DB_DATABASE.watchdog --no-create-info --no-tablespaces --skip-triggers -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE >> $dump && cat $dump && rm $dump"
   fileExtension: .mariadb-database.sql
   pod:
     metadata: {}

--- a/internal/templating/backups/test-resources/result-prebackuppod4.yaml
+++ b/internal/templating/backups/test-resources/result-prebackuppod4.yaml
@@ -20,7 +20,7 @@ metadata:
   name: mariadb-database-prebackuppod
 spec:
   backupCommand: |
-    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1); fi && dump=$(mktemp) && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --no-data --no-tablespaces -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE > $dump && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --ignore-table=$BACKUP_DB_DATABASE.watchdog --no-create-info --no-tablespaces --skip-triggers -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE >> $dump && cat $dump && rm $dump"
+    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1); fi && dump=$(mktemp) && mysqldump --max-allowed-packet=1G --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --no-data --no-tablespaces -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE > $dump && mysqldump --max-allowed-packet=1G --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --ignore-table=$BACKUP_DB_DATABASE.watchdog --no-create-info --no-tablespaces --skip-triggers -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE >> $dump && cat $dump && rm $dump"
   fileExtension: .mariadb-database.sql
   pod:
     metadata: {}

--- a/internal/templating/backups/test-resources/result-prebackuppod5.yaml
+++ b/internal/templating/backups/test-resources/result-prebackuppod5.yaml
@@ -20,7 +20,7 @@ metadata:
   name: mariadb-database-prebackuppod
 spec:
   backupCommand: |
-    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1); fi && dump=$(mktemp) && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --no-data --no-tablespaces -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE > $dump && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --ignore-table=$BACKUP_DB_DATABASE.watchdog --no-create-info --no-tablespaces --skip-triggers -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE >> $dump && cat $dump && rm $dump"
+    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1); fi && dump=$(mktemp) && mysqldump --max-allowed-packet=1G --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --no-data --no-tablespaces -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE > $dump && mysqldump --max-allowed-packet=1G --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --ignore-table=$BACKUP_DB_DATABASE.watchdog --no-create-info --no-tablespaces --skip-triggers -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE >> $dump && cat $dump && rm $dump"
   fileExtension: .mariadb-database.sql
   pod:
     metadata: {}
@@ -81,7 +81,7 @@ metadata:
   name: mariadb-prebackuppod
 spec:
   backupCommand: |
-    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1); fi && dump=$(mktemp) && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --no-data --no-tablespaces -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE > $dump && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --ignore-table=$BACKUP_DB_DATABASE.watchdog --no-create-info --no-tablespaces --skip-triggers -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE >> $dump && cat $dump && rm $dump"
+    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1); fi && dump=$(mktemp) && mysqldump --max-allowed-packet=1G --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --no-data --no-tablespaces -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE > $dump && mysqldump --max-allowed-packet=1G --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --ignore-table=$BACKUP_DB_DATABASE.watchdog --no-create-info --no-tablespaces --skip-triggers -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE >> $dump && cat $dump && rm $dump"
   fileExtension: .mariadb.sql
   pod:
     metadata: {}

--- a/internal/testdata/complex/backup-templates/backup-1/prebackuppods.yaml
+++ b/internal/testdata/complex/backup-templates/backup-1/prebackuppods.yaml
@@ -20,7 +20,7 @@ metadata:
   name: mariadb-prebackuppod
 spec:
   backupCommand: |
-    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1); fi && dump=$(mktemp) && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --no-data --no-tablespaces -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE > $dump && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --ignore-table=$BACKUP_DB_DATABASE.watchdog --no-create-info --no-tablespaces --skip-triggers -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE >> $dump && cat $dump && rm $dump"
+    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1); fi && dump=$(mktemp) && mysqldump --max-allowed-packet=1G --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --no-data --no-tablespaces -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE > $dump && mysqldump --max-allowed-packet=1G --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --ignore-table=$BACKUP_DB_DATABASE.watchdog --no-create-info --no-tablespaces --skip-triggers -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE >> $dump && cat $dump && rm $dump"
   fileExtension: .mariadb.sql
   pod:
     metadata: {}

--- a/internal/testdata/complex/backup-templates/backup-2/prebackuppods.yaml
+++ b/internal/testdata/complex/backup-templates/backup-2/prebackuppods.yaml
@@ -20,7 +20,7 @@ metadata:
   name: mariadb-prebackuppod
 spec:
   backupCommand: |
-    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1); fi && dump=$(mktemp) && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --no-data --no-tablespaces -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE > $dump && mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --ignore-table=$BACKUP_DB_DATABASE.watchdog --no-create-info --no-tablespaces --skip-triggers -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE >> $dump && cat $dump && rm $dump"
+    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1); fi && dump=$(mktemp) && mysqldump --max-allowed-packet=1G --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --no-data --no-tablespaces -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE > $dump && mysqldump --max-allowed-packet=1G --events --routines --quick --add-locks --no-autocommit --single-transaction --no-create-db --ignore-table=$BACKUP_DB_DATABASE.watchdog --no-create-info --no-tablespaces --skip-triggers -h $BACKUP_DB_HOST -u $BACKUP_DB_USERNAME -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE >> $dump && cat $dump && rm $dump"
   fileExtension: .mariadb.sql
   pod:
     metadata: {}

--- a/legacy/helmcharts/mariadb-single/templates/deployment.yaml
+++ b/legacy/helmcharts/mariadb-single/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{- end }}
       annotations:
         {{- include "mariadb-single.annotations" . | nindent 8 }}
-        k8up.syn.tools/backupcommand: /bin/sh -c 'mysqldump --max-allowed-packet=500M --events --routines --quick --add-locks --no-autocommit --single-transaction --all-databases'
+        k8up.syn.tools/backupcommand: /bin/sh -c 'mysqldump --max-allowed-packet=1G --events --routines --quick --add-locks --no-autocommit --single-transaction --all-databases'
         k8up.syn.tools/file-extension: .{{ include "mariadb-single.fullname" . }}.sql
         lagoon.sh/configMapSha: {{ .Values.configMapSha | quote }}
     spec:


### PR DESCRIPTION
Based on discussion in #323 this just sets the max-allowed-packet to be the maximum supported.

closes #323 