### PR TITLE
fix: add LAGOON_CACHE_ build arg support back

### DIFF
--- a/cmd/identify_imagebuild_test.go
+++ b/cmd/identify_imagebuild_test.go
@@ -563,6 +563,45 @@ func TestImageBuildConfigurationIdentification(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "test9 basic deployment with cache args",
+			args: testdata.GetSeedData(
+				testdata.TestData{
+					Namespace:               "example-project-main",
+					ProjectName:             "example-project",
+					EnvironmentName:         "main",
+					Branch:                  "main",
+					LagoonYAML:              "internal/testdata/basic/lagoon.yml",
+					ImageCacheBuildArgsJSON: `[{"image":"harbor.example/example-project/main/node@sha256:e90daba405cbf33bab23fe8a021146811b2c258df5f2afe7dadc92c0778eef45","name":"node"}]`,
+				}, true),
+			want: imageBuild{
+				BuildKit: false,
+				BuildArguments: map[string]string{
+					"LAGOON_BUILD_NAME":            "lagoon-build-abcdefg",
+					"LAGOON_PROJECT":               "example-project",
+					"LAGOON_ENVIRONMENT":           "main",
+					"LAGOON_ENVIRONMENT_TYPE":      "production",
+					"LAGOON_BUILD_TYPE":            "branch",
+					"LAGOON_GIT_SOURCE_REPOSITORY": "ssh://git@example.com/lagoon-demo.git",
+					"LAGOON_KUBERNETES":            "remote-cluster1",
+					"LAGOON_GIT_SHA":               "abcdefg123456",
+					"LAGOON_GIT_BRANCH":            "main",
+					"NODE_IMAGE":                   "example-project-main-node",
+					"LAGOON_CACHE_node":            "harbor.example/example-project/main/node@sha256:e90daba405cbf33bab23fe8a021146811b2c258df5f2afe7dadc92c0778eef45",
+				},
+				Images: []imageBuilds{
+					{
+						Name: "node",
+						ImageBuild: generator.ImageBuild{
+							BuildImage:     "harbor.example/example-project/main/node:latest",
+							Context:        "internal/testdata/basic/docker",
+							DockerFile:     "basic.dockerfile",
+							TemporaryImage: "example-project-main-node",
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/generator/build_data.go
+++ b/internal/generator/build_data.go
@@ -81,5 +81,9 @@ func collectImageBuildArguments(buildValues BuildValues) map[string]string {
 			buildArgs[fmt.Sprintf("%s_IMAGE", strings.ToUpper(service.Name))] = service.ImageBuild.TemporaryImage
 		}
 	}
+	// add lagoon image cache build arguments
+	for _, icba := range buildValues.ImageCacheBuildArguments {
+		buildArgs[fmt.Sprintf("LAGOON_CACHE_%s", icba.Name)] = icba.Image
+	}
 	return buildArgs
 }

--- a/internal/generator/buildvalues.go
+++ b/internal/generator/buildvalues.go
@@ -77,6 +77,7 @@ type BuildValues struct {
 	RoutesAutogeneratePrefixes    []string                     `json:"routesAutogeneratePrefixes"`
 	BackupsEnabled                bool                         `json:"backupsEnabled"`
 	RouteQuota                    *int                         `json:"routeQuota"`
+	ImageCacheBuildArguments      []ImageCacheBuildArguments   `json:"imageCacheBuildArgs"`
 }
 
 type Resources struct {
@@ -136,6 +137,11 @@ type DynamicSecretVolumes struct {
 type DynamicSecret struct {
 	SecretName string `json:"secretName"`
 	Optional   bool   `json:"optional"`
+}
+
+type ImageCacheBuildArguments struct {
+	Image string `json:"image"`
+	Name  string `json:"name"`
 }
 
 // ServiceValues is the values for a specific service used by a lagoon build

--- a/internal/testdata/testdata.go
+++ b/internal/testdata/testdata.go
@@ -57,6 +57,7 @@ type TestData struct {
 	PrivateRegistryURLS        []string
 	DynamicSecrets             []string
 	DynamicDBaaSSecrets        []string
+	ImageCacheBuildArgsJSON    string
 }
 
 // helper function to set up all the environment variables from provided testdata
@@ -184,6 +185,10 @@ func SetupEnvironment(rootCmd cobra.Command, templatePath string, t TestData) (g
 		return generator.GeneratorInput{}, err
 	}
 	err = os.Setenv("DYNAMIC_DBAAS_SECRETS", strings.Join(t.DynamicDBaaSSecrets, ","))
+	if err != nil {
+		return generator.GeneratorInput{}, err
+	}
+	err = os.Setenv("LAGOON_CACHE_BUILD_ARGS", t.ImageCacheBuildArgsJSON)
 	if err != nil {
 		return generator.GeneratorInput{}, err
 	}
@@ -326,6 +331,9 @@ func GetSeedData(t TestData, defaultProjectVariables bool) TestData {
 	}
 	if t.DynamicDBaaSSecrets != nil {
 		rt.DynamicDBaaSSecrets = t.DynamicDBaaSSecrets
+	}
+	if t.ImageCacheBuildArgsJSON != "" {
+		rt.ImageCacheBuildArgsJSON = t.ImageCacheBuildArgsJSON
 	}
 	return rt
 }


### PR DESCRIPTION
This PR restores the LAGOON_CACHE_  functionality into the correct place in the build to allow the ARGS to be used