### PR TITLE
build: add gha cache for go and docker

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,10 +10,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Install Go
-      uses: actions/setup-go@v4
+    - name: Setup Go
+      uses: actions/setup-go@v5
       with:
-        go-version: "^1.21"
+        go-version: '1.21'
+        cache-dependency-path: ./go.mod
     - name: Set up environment
       run: echo "GOVERSION=$(go version)" >> $GITHUB_ENV
     - name: Run GoReleaser

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -97,6 +97,25 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - 
+        name: Cache
+        uses: actions/cache@v4
+        id: cache
+        with:
+          path: |
+            go-mod
+            go-build
+          key: cache-${{ hashFiles('**/go.mod') }}
+      - 
+        name: inject cache into docker
+        uses: reproducible-containers/buildkit-cache-dance@v3.1.0
+        with:
+          cache-map: |
+            {
+              "go-mod": "/go/pkg/mod",
+              "go-build": "/root/.cache/go-build"
+            }
+          skip-extraction: ${{ steps.cache.outputs.cache-hit }}
       -
         name: Build and push
         uses: docker/build-push-action@v5
@@ -107,6 +126,8 @@ jobs:
             "VERSION=${{ env.VERSION }}"
             "BUILD=${{ env.BUILD }}"
             "GO_VER=${{ matrix.goversion }}"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,9 +6,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Install Go
-      uses: actions/setup-go@v4
+    - name: Setup Go
+      uses: actions/setup-go@v5
       with:
-        go-version: "^1.21"
+        go-version: '1.21'
+        cache-dependency-path: ./go.mod
     - name: Run Tests
       run: go test -v ./...


### PR DESCRIPTION
This PR introduces go and docker caching into the github actions.

In addition, there is now docker layer caching available, so the non-golang layers will also be cached, which can speed up the builds from 12 to 10 minutes.

It uses a hash of go.mod - so if no golang changes are made, the cache is available to the build to use, which can speed up builds from 10 to 2 minutes.

