### PR TITLE
feat: implement feature to fail builds on docker-compose yaml errors

### DIFF
--- a/legacy/build-deploy-docker-compose.sh
+++ b/legacy/build-deploy-docker-compose.sh
@@ -255,11 +255,36 @@ dccExit2=$?
 if [ "${dccExit2}" != "0" ]; then
   ((++DOCKER_COMPOSE_WARNING_COUNT))
   if [ "${dccExit}" == "0" ]; then
+
+    # this logic is to phase rollout of https://github.com/uselagoon/build-deploy-tool/pull/304
+    # anything returned by this section will be a yaml error that we need to check if the feature to enable/disable errors
+    # is configured, and that the environment type matches.
+    # eventually this logic will be changed entirely from warnings to errors
+    DOCKER_COMPOSE_VALIDATION_ERROR=false
+    # this logic will make development environments return an error by default
+    # adding LAGOON_FEATURE_FLAG_DEVELOPMENT_DOCKER_COMPOSE_VALIDATION=disabled can be used to disable the error and revert to a warning per project or environment
+    # or add LAGOON_FEATURE_FLAG_DEFAULT_DEVELOPMENT_DOCKER_COMPOSE_VALIDATION=disabled to the remote-controller as a default to disable for a cluster
+    if [[ "$(featureFlag DEVELOPMENT_DOCKER_COMPOSE_VALIDATION)" != disabled ]] && [[ "$ENVIRONMENT_TYPE" == "development" ]]; then
+      DOCKER_COMPOSE_VALIDATION_ERROR=true
+    fi
+    # by default, production environments won't return an error unless the feature flag is enabled.
+    # this allows using the feature flag to selectively apply to production environments if required
+    # adding LAGOON_FEATURE_FLAG_PRODUCTION_DOCKER_COMPOSE_VALIDATION=enabled can be used to enable the error per project or environment
+    # or add LAGOON_FEATURE_FLAG_DEFAULT_PRODUCTION_DOCKER_COMPOSE_VALIDATION=enabled to the remote-controller as a default to disable for a cluster
+    if [[ "$(featureFlag PRODUCTION_DOCKER_COMPOSE_VALIDATION)" = enabled ]] && [[ "$ENVIRONMENT_TYPE" == "production" ]]; then
+      DOCKER_COMPOSE_VALIDATION_ERROR=true
+    fi
+
     ((++BUILD_WARNING_COUNT))
     echo "
-##############################################
-Warning!
-There are issues with your docker compose file that lagoon uses that should be fixed.
+##############################################"
+    if [[ "$DOCKER_COMPOSE_VALIDATION_ERROR" == "true" ]]; then
+      echo "Error!"
+    else
+      echo "Warning!"
+    fi
+
+    echo "There are issues with your docker compose file that lagoon uses that should be fixed.
 You can run docker compose config locally to check that your docker-compose file is valid.
 "
   fi
@@ -279,6 +304,12 @@ else
   currentStepEnd="$(date +"%Y-%m-%d %H:%M:%S")"
   patchBuildStep "${buildStartTime}" "${previousStepEnd}" "${currentStepEnd}" "${NAMESPACE}" "dockerComposeValidation" "Docker Compose Validation" "false"
   previousStepEnd=${currentStepEnd}
+fi
+
+
+if [[ "$DOCKER_COMPOSE_VALIDATION_ERROR" == "true" ]]; then
+  # drop the exit here if this should be an error
+  exit 1
 fi
 
 beginBuildStep ".lagoon.yml Validation" "lagoonYmlValidation"

--- a/legacy/build-deploy-docker-compose.sh
+++ b/legacy/build-deploy-docker-compose.sh
@@ -261,6 +261,7 @@ if [ "${dccExit2}" != "0" ]; then
     # is configured, and that the environment type matches.
     # eventually this logic will be changed entirely from warnings to errors
     DOCKER_COMPOSE_VALIDATION_ERROR=false
+    DOCKER_COMPOSE_VALIDATION_ERROR_VARIABLE=LAGOON_FEATURE_FLAG_DEVELOPMENT_DOCKER_COMPOSE_VALIDATION
     # this logic will make development environments return an error by default
     # adding LAGOON_FEATURE_FLAG_DEVELOPMENT_DOCKER_COMPOSE_VALIDATION=disabled can be used to disable the error and revert to a warning per project or environment
     # or add LAGOON_FEATURE_FLAG_DEFAULT_DEVELOPMENT_DOCKER_COMPOSE_VALIDATION=disabled to the remote-controller as a default to disable for a cluster
@@ -273,6 +274,7 @@ if [ "${dccExit2}" != "0" ]; then
     # or add LAGOON_FEATURE_FLAG_DEFAULT_PRODUCTION_DOCKER_COMPOSE_VALIDATION=enabled to the remote-controller as a default to disable for a cluster
     if [[ "$(featureFlag PRODUCTION_DOCKER_COMPOSE_VALIDATION)" = enabled ]] && [[ "$ENVIRONMENT_TYPE" == "production" ]]; then
       DOCKER_COMPOSE_VALIDATION_ERROR=true
+    DOCKER_COMPOSE_VALIDATION_ERROR_VARIABLE=LAGOON_FEATURE_FLAG_PRODUCTION_DOCKER_COMPOSE_VALIDATION
     fi
 
     ((++BUILD_WARNING_COUNT))
@@ -309,6 +311,10 @@ fi
 
 if [[ "$DOCKER_COMPOSE_VALIDATION_ERROR" == "true" ]]; then
   # drop the exit here if this should be an error
+  echo "> You can instruct Lagoon to change this to a warning by setting the following variable"
+  echo "> '${DOCKER_COMPOSE_VALIDATION_ERROR_VARIABLE}=disabled' as a GLOBAL scoped variable to this environment or project."
+  echo "> A future release of Lagoon will not be able to change this error."
+  echo "> You should correct the issue as soon as possible to prevent future build failures."
   exit 1
 fi
 


### PR DESCRIPTION
To help make #304 a reality, this is a phased approach to implement the failure that is detected if a docker-compose file has yaml errors that need to be addressed.

By default, this will make `development` type environments builds fail. It is possible to disable this error using the feature flags
```
# per project/environment
LAGOON_FEATURE_FLAG_DEVELOPMENT_DOCKER_COMPOSE_VALIDATION=disabled

# per cluster in the remote-controller
LAGOON_FEATURE_FLAG_DEFAULT_DEVELOPMENT_DOCKER_COMPOSE_VALIDATION=disabled
```

Production environments will continue to warn, but it is possible to enable the errors using feature flags
```
# per project/environment
LAGOON_FEATURE_FLAG_PRODUCTION_DOCKER_COMPOSE_VALIDATION=enabled

# per cluster in the remote-controller
LAGOON_FEATURE_FLAG_DEFAULT_PRODUCTION_DOCKER_COMPOSE_VALIDATION=enabled
```
Eventually though, the warnings will become failures with no way to disable the error as we upgrade the library.
We will announce before this takes place though.

As warnings have been available in builds for over 6 months now, and these errors are thrown if you're using a new version of docker compose locally, most users will likely have addressed these problems if they had them.

Information about how to temporarily disable the error are presented in the output of the error so that users are able to resolve.

---

This has been flagged for 2.22.0 so that at least for amazeeio there will be time for communication to be provided. The release notes of 2.21.0 should mention this change as coming in 2.22.0 for open source users to be aware of.