### PR TITLE
fix: check usespot before applying replicas

### DIFF
--- a/internal/generator/services.go
+++ b/internal/generator/services.go
@@ -381,7 +381,7 @@ func composeToServiceValues(
 		// check if the this service is production and can support 2 replicas on spot
 		for _, t := range strings.Split(spotReplicaTypes, ",") {
 			if t != "" {
-				if t == lagoonType && buildValues.EnvironmentType == "production" {
+				if t == lagoonType && buildValues.EnvironmentType == "production" && useSpot {
 					spotReplicas = 2
 				}
 			}

--- a/internal/testdata/complex/service-templates/service1/deployment-nginx-php.yaml
+++ b/internal/testdata/complex/service-templates/service1/deployment-nginx-php.yaml
@@ -19,7 +19,7 @@ metadata:
     lagoon.sh/template: nginx-php-persistent-0.1.0
   name: nginx-php
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: nginx-php

--- a/internal/testdata/complex/service-templates/service2/deployment-nginx-php.yaml
+++ b/internal/testdata/complex/service-templates/service2/deployment-nginx-php.yaml
@@ -19,7 +19,7 @@ metadata:
     lagoon.sh/template: nginx-php-persistent-0.1.0
   name: nginx-php
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: nginx-php


### PR DESCRIPTION
Fix the check for adding replicas for production environments when spot is enabled