### PR TITLE
fix: polysite cronjob inheritence from lagoon yaml

### DIFF
--- a/cmd/template_lagoonservices_test.go
+++ b/cmd/template_lagoonservices_test.go
@@ -283,6 +283,21 @@ func TestTemplateLagoonServices(t *testing.T) {
 			templatePath: "testoutput",
 			want:         "internal/testdata/complex/service-templates/service4",
 		},
+		{
+			name: "test10 basic deployment polysite cronjobs",
+			args: testdata.GetSeedData(
+				testdata.TestData{
+					ProjectName:     "example-project",
+					EnvironmentName: "main",
+					Branch:          "main",
+					LagoonYAML:      "internal/testdata/basic/lagoon.polysite-cronjobs.yml",
+					ImageReferences: map[string]string{
+						"node": "harbor.example/example-project/main/node@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8",
+					},
+				}, true),
+			templatePath: "testoutput",
+			want:         "internal/testdata/basic/service-templates/service7",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/lagoon/lagoon_test.go
+++ b/internal/lagoon/lagoon_test.go
@@ -312,6 +312,12 @@ func TestUnmarshalLagoonYAML(t *testing.T) {
 								Service:  "cli",
 								Schedule: "*/15 * * * *",
 							},
+							{
+								Name:     "some other drush cron",
+								Command:  "drush cron",
+								Service:  "cli",
+								Schedule: "*/5 * * * *",
+							},
 						},
 					},
 				},
@@ -391,6 +397,44 @@ func TestUnmarshalLagoonYAML(t *testing.T) {
 										},
 									},
 								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "test-polysite without project environment cronjobs",
+			args: args{
+				file:    "test-resources/lagoon-yaml/test9/lagoon.yml",
+				l:       &YAML{},
+				project: "multiproject1",
+			},
+			want: &YAML{
+				DockerComposeYAML: "docker-compose.yml",
+				Environments: Environments{
+					"main": Environment{
+						Routes: []map[string][]Route{
+							{
+								"nginx": {
+									{
+										Name: "a.example.com",
+									},
+								},
+							},
+						},
+						Cronjobs: []Cronjob{
+							{
+								Name:     "drush cron",
+								Command:  "drush cron",
+								Service:  "cli",
+								Schedule: "*/5 * * * *",
+							},
+							{
+								Name:     "some other drush cron",
+								Command:  "drush cron",
+								Service:  "cli",
+								Schedule: "*/5 * * * *",
 							},
 						},
 					},

--- a/internal/lagoon/test-resources/lagoon-yaml/test9/lagoon.yml
+++ b/internal/lagoon/test-resources/lagoon-yaml/test9/lagoon.yml
@@ -6,11 +6,6 @@ project: content-example-com
 multiproject1:
   environments:
     main:
-      cronjobs:
-        - name: drush cron
-          schedule: "*/15 * * * *"
-          command: 'drush cron'
-          service: cli
       routes:
       -   nginx:
           - a.example.com
@@ -30,7 +25,7 @@ multiproject2:
 environments:
   main:
     cronjobs:
-      - name: "drush cron" #this cronjob should be ignored as a more specific polysite project cronjob of the same name is defined
+      - name: "drush cron"
         schedule: "*/5 * * * *"
         command: 'drush cron'
         service: cli

--- a/internal/testdata/basic/lagoon.polysite-cronjobs.yml
+++ b/internal/testdata/basic/lagoon.polysite-cronjobs.yml
@@ -1,0 +1,30 @@
+docker-compose-yaml: internal/testdata/basic/docker-compose.yml
+
+environment_variables:
+  git_sha: "true"
+
+example-project:
+  environments:
+    main:
+      cronjobs:
+        - name: drush cron
+          schedule: "*/15 0 * * *"
+          command: 'drush cron'
+          service: node
+      routes:
+      -   nginx:
+          - a.example.com
+
+environments:
+  main:
+    cronjobs:
+      - name: "drush cron" #this cronjob should be ignored as a more specific polysite project cronjob of the same name is defined
+        schedule: "*/5 0 * * *"
+        command: 'drush cron'
+        service: node
+        shell: bash
+      - name: "some other drush cron"
+        schedule: "10 2 * * *"
+        command: 'drush cron'
+        service: node
+        shell: bash

--- a/internal/testdata/basic/service-templates/service7/cronjob-cronjob-node-some-other-drush-cron.yaml
+++ b/internal/testdata/basic/service-templates/service7/cronjob-cronjob-node-some-other-drush-cron.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: build-deploy-tool
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: node
+    lagoon.sh/service-type: basic
+    lagoon.sh/template: basic-0.1.0
+  name: cronjob-node-some-other-drush-cron
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          annotations:
+            lagoon.sh/branch: main
+            lagoon.sh/configMapSha: abcdefg1234567890
+            lagoon.sh/version: v2.7.x
+          creationTimestamp: null
+          labels:
+            app.kubernetes.io/managed-by: build-deploy-tool
+            lagoon.sh/buildType: branch
+            lagoon.sh/environment: main
+            lagoon.sh/environmentType: production
+            lagoon.sh/project: example-project
+            lagoon.sh/service: node
+            lagoon.sh/service-type: basic
+            lagoon.sh/template: basic-0.1.0
+        spec:
+          containers:
+          - command:
+            - /lagoon/cronjob.sh
+            - drush cron
+            env:
+            - name: LAGOON_GIT_SHA
+              value: abcdefg123456
+            - name: SERVICE_NAME
+              value: node
+            envFrom:
+            - configMapRef:
+                name: lagoon-env
+            image: harbor.example/example-project/main/node@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8
+            imagePullPolicy: Always
+            name: cronjob-node-some-other-drush-cron
+            resources:
+              requests:
+                cpu: 10m
+                memory: 10Mi
+            securityContext: {}
+          dnsConfig:
+            options:
+            - name: timeout
+              value: "60"
+            - name: attempts
+              value: "10"
+          enableServiceLinks: false
+          imagePullSecrets:
+          - name: lagoon-internal-registry-secret
+          priorityClassName: lagoon-priority-production
+          restartPolicy: Never
+  schedule: 10 2 * * *
+  startingDeadlineSeconds: 240
+  successfulJobsHistoryLimit: 0
+status: {}

--- a/internal/testdata/basic/service-templates/service7/deployment-node.yaml
+++ b/internal/testdata/basic/service-templates/service7/deployment-node.yaml
@@ -1,0 +1,91 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: node
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: basic
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: node
+    lagoon.sh/service-type: basic
+    lagoon.sh/template: basic-0.1.0
+  name: node
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: node
+      app.kubernetes.io/name: basic
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        lagoon.sh/branch: main
+        lagoon.sh/configMapSha: abcdefg1234567890
+        lagoon.sh/version: v2.7.x
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: node
+        app.kubernetes.io/managed-by: build-deploy-tool
+        app.kubernetes.io/name: basic
+        lagoon.sh/buildType: branch
+        lagoon.sh/environment: main
+        lagoon.sh/environmentType: production
+        lagoon.sh/project: example-project
+        lagoon.sh/service: node
+        lagoon.sh/service-type: basic
+        lagoon.sh/template: basic-0.1.0
+    spec:
+      containers:
+      - env:
+        - name: LAGOON_GIT_SHA
+          value: abcdefg123456
+        - name: CRONJOBS
+          value: |
+            3,18,33,48 0 * * * drush cron
+        - name: SERVICE_NAME
+          value: node
+        envFrom:
+        - configMapRef:
+            name: lagoon-env
+        image: harbor.example/example-project/main/node@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8
+        imagePullPolicy: Always
+        livenessProbe:
+          initialDelaySeconds: 60
+          tcpSocket:
+            port: 1234
+          timeoutSeconds: 10
+        name: basic
+        ports:
+        - containerPort: 1234
+          name: tcp-1234
+          protocol: TCP
+        - containerPort: 8191
+          name: tcp-8191
+          protocol: TCP
+        - containerPort: 9001
+          name: udp-9001
+          protocol: UDP
+        readinessProbe:
+          initialDelaySeconds: 1
+          tcpSocket:
+            port: 1234
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext: {}
+      enableServiceLinks: false
+      imagePullSecrets:
+      - name: lagoon-internal-registry-secret
+      priorityClassName: lagoon-priority-production
+status: {}

--- a/internal/testdata/basic/service-templates/service7/service-node.yaml
+++ b/internal/testdata/basic/service-templates/service7/service-node.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: node
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: basic
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: node
+    lagoon.sh/service-type: basic
+    lagoon.sh/template: basic-0.1.0
+  name: node
+spec:
+  ports:
+  - name: tcp-1234
+    port: 1234
+    protocol: TCP
+    targetPort: tcp-1234
+  - name: tcp-8191
+    port: 8191
+    protocol: TCP
+    targetPort: tcp-8191
+  - name: udp-9001
+    port: 9001
+    protocol: UDP
+    targetPort: udp-9001
+  selector:
+    app.kubernetes.io/instance: node
+    app.kubernetes.io/name: basic
+status:
+  loadBalancer: {}


### PR DESCRIPTION
Polysite cronjob inheritence was broken in the lagoon yaml processor.

This fixes it so that if a polysite project has cronjobs defined, it will still inherit the `environments.$env.cronjobs` and merge them onto the `$project.environments.$env.cronjobs`

Added and updated tests to include this processor for cronjobs on polysites in the lagoon yaml processor