### PR TITLE
fix: more supported cron values

### DIFF
--- a/internal/helpers/helpers_cron.go
+++ b/internal/helpers/helpers_cron.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -180,6 +181,10 @@ func ConvertCrontab(namespace, cron string) (string, error) {
 					months = val
 					continue
 				}
+				if isMonth(val) {
+					months = val
+					continue
+				}
 				// if the value is not valid, return an error with where the issue is
 				if months == "" {
 					return "", fmt.Errorf("cron definition '%s' is invalid, unable to determine months value", cron)
@@ -195,6 +200,10 @@ func ConvertCrontab(namespace, cron string) (string, error) {
 					continue
 				}
 				if val == "*" {
+					dayweek = val
+					continue
+				}
+				if isDayOfWeek(val) {
 					dayweek = val
 					continue
 				}
@@ -266,6 +275,18 @@ func isInCSVRange(s string, min, max int) bool {
 		}
 	}
 	return true
+}
+
+// check if the provided cron day string is a valid
+func isDayOfWeek(s string) bool {
+	days := []string{"SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"}
+	return slices.Contains(days, strings.ToUpper(s))
+}
+
+// check if the provided cron month string is a valid
+func isMonth(s string) bool {
+	days := []string{"JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"}
+	return slices.Contains(days, strings.ToUpper(s))
 }
 
 // check if the provided cron time definition is a valid `1-2` type range

--- a/internal/helpers/helpers_cron_test.go
+++ b/internal/helpers/helpers_cron_test.go
@@ -151,6 +151,14 @@ func TestConvertCrontab(t *testing.T) {
 			},
 			want: "31 1,7,13,19 * * *",
 		},
+		{
+			name: "test18 - day and month string",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "M */6 * JAN MON",
+			},
+			want: "31 1,7,13,19 * JAN MON",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The old crontab generator just passed through values for day and month: https://github.com/uselagoon/build-deploy-tool/blob/a4fc0b326fc144b3f17653d7a1da570ad43a900d/legacy/scripts/convert-crontab.sh#L90-L95 while the new cron validates them.

Some values were not included in the validations, this PR addresses those.

http://man.he.net/man5/crontab
```
       # Example of job definition:
       # .---------------- minute (0 - 59)
       # |  .------------- hour (0 - 23)
       # |  |  .---------- day of month (1 - 31)
       # |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
       # |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
       # |  |  |  |  |
```