### PR TITLE
fix: additional templating and logic fixes

### DIFF
--- a/cmd/identify_imagebuild_test.go
+++ b/cmd/identify_imagebuild_test.go
@@ -46,6 +46,7 @@ func TestImageBuildConfigurationIdentification(t *testing.T) {
 					"LAGOON_GIT_SHA":               "abcdefg123456",
 					"LAGOON_GIT_BRANCH":            "main",
 					"NODE_IMAGE":                   "example-project-main-node",
+					"LAGOON_SSH_PRIVATE_KEY":       "-----BEGIN OPENSSH PRIVATE KEY-----\nthisisafakekey\n-----END OPENSSH PRIVATE KEY-----",
 				},
 				Images: []imageBuilds{
 					{
@@ -85,6 +86,7 @@ func TestImageBuildConfigurationIdentification(t *testing.T) {
 					"CLI_IMAGE":                    "example-project-main-cli",
 					"NGINX_IMAGE":                  "example-project-main-nginx",
 					"PHP_IMAGE":                    "example-project-main-php",
+					"LAGOON_SSH_PRIVATE_KEY":       "-----BEGIN OPENSSH PRIVATE KEY-----\nthisisafakekey\n-----END OPENSSH PRIVATE KEY-----",
 				},
 				Images: []imageBuilds{
 					{
@@ -172,6 +174,7 @@ func TestImageBuildConfigurationIdentification(t *testing.T) {
 					"NGINX_IMAGE":                             "example-project-main-nginx",
 					"PHP_IMAGE":                               "example-project-main-php",
 					"LAGOON_FEATURE_FLAG_IMAGECACHE_REGISTRY": "imagecache.example.com",
+					"LAGOON_SSH_PRIVATE_KEY":                  "-----BEGIN OPENSSH PRIVATE KEY-----\nthisisafakekey\n-----END OPENSSH PRIVATE KEY-----",
 				},
 				Images: []imageBuilds{
 					{
@@ -247,6 +250,7 @@ func TestImageBuildConfigurationIdentification(t *testing.T) {
 					"LND_IMAGE":                             "example-project-main-lnd",
 					"THUNDERHUB_IMAGE":                      "example-project-main-thunderhub",
 					"TOR_IMAGE":                             "example-project-main-tor",
+					"LAGOON_SSH_PRIVATE_KEY":                "-----BEGIN OPENSSH PRIVATE KEY-----\nthisisafakekey\n-----END OPENSSH PRIVATE KEY-----",
 				},
 				Images: []imageBuilds{
 					{
@@ -315,6 +319,7 @@ func TestImageBuildConfigurationIdentification(t *testing.T) {
 					"LAGOON_GIT_BRANCH":                     "main",
 					"LND_IMAGE":                             "example-project-main-lnd",
 					"TOR_IMAGE":                             "example-project-main-tor",
+					"LAGOON_SSH_PRIVATE_KEY":                "-----BEGIN OPENSSH PRIVATE KEY-----\nthisisafakekey\n-----END OPENSSH PRIVATE KEY-----",
 				},
 				Images: []imageBuilds{
 					{
@@ -358,6 +363,7 @@ func TestImageBuildConfigurationIdentification(t *testing.T) {
 					"LAGOON_BUILD_TYPE":            "promote",
 					"LAGOON_GIT_SOURCE_REPOSITORY": "ssh://git@example.com/lagoon-demo.git",
 					"LAGOON_KUBERNETES":            "remote-cluster1",
+					"LAGOON_SSH_PRIVATE_KEY":       "-----BEGIN OPENSSH PRIVATE KEY-----\nthisisafakekey\n-----END OPENSSH PRIVATE KEY-----",
 				},
 				Images: []imageBuilds{
 					{
@@ -406,6 +412,7 @@ func TestImageBuildConfigurationIdentification(t *testing.T) {
 					"LAGOON_GIT_SOURCE_REPOSITORY": "ssh://git@example.com/lagoon-demo.git",
 					"LAGOON_KUBERNETES":            "remote-cluster1",
 					"NODE_IMAGE":                   "example-project-pr-123-node",
+					"LAGOON_SSH_PRIVATE_KEY":       "-----BEGIN OPENSSH PRIVATE KEY-----\nthisisafakekey\n-----END OPENSSH PRIVATE KEY-----",
 				},
 				Images: []imageBuilds{
 					{
@@ -441,6 +448,7 @@ func TestImageBuildConfigurationIdentification(t *testing.T) {
 					"LAGOON_BUILD_TYPE":            "promote",
 					"LAGOON_GIT_SOURCE_REPOSITORY": "ssh://git@example.com/lagoon-demo.git",
 					"LAGOON_KUBERNETES":            "remote-cluster1",
+					"LAGOON_SSH_PRIVATE_KEY":       "-----BEGIN OPENSSH PRIVATE KEY-----\nthisisafakekey\n-----END OPENSSH PRIVATE KEY-----",
 				},
 				Images: []imageBuilds{
 					{
@@ -510,6 +518,7 @@ func TestImageBuildConfigurationIdentification(t *testing.T) {
 					"NGINX_IMAGE":                             "example-project-main-nginx",
 					"PHP_IMAGE":                               "example-project-main-php",
 					"LAGOON_FEATURE_FLAG_IMAGECACHE_REGISTRY": "imagecache.example.com",
+					"LAGOON_SSH_PRIVATE_KEY":                  "-----BEGIN OPENSSH PRIVATE KEY-----\nthisisafakekey\n-----END OPENSSH PRIVATE KEY-----",
 				},
 				ContainerRegistries: []generator.ContainerRegistry{
 					{
@@ -588,6 +597,7 @@ func TestImageBuildConfigurationIdentification(t *testing.T) {
 					"LAGOON_GIT_BRANCH":            "main",
 					"NODE_IMAGE":                   "example-project-main-node",
 					"LAGOON_CACHE_node":            "harbor.example/example-project/main/node@sha256:e90daba405cbf33bab23fe8a021146811b2c258df5f2afe7dadc92c0778eef45",
+					"LAGOON_SSH_PRIVATE_KEY":       "-----BEGIN OPENSSH PRIVATE KEY-----\nthisisafakekey\n-----END OPENSSH PRIVATE KEY-----",
 				},
 				Images: []imageBuilds{
 					{
@@ -635,6 +645,7 @@ func TestImageBuildConfigurationIdentification(t *testing.T) {
 					"NGINX_IMAGE":                             "example-project-main-nginx",
 					"PHP_IMAGE":                               "example-project-main-php",
 					"LAGOON_FEATURE_FLAG_IMAGECACHE_REGISTRY": "imagecache.example.com",
+					"LAGOON_SSH_PRIVATE_KEY":                  "-----BEGIN OPENSSH PRIVATE KEY-----\nthisisafakekey\n-----END OPENSSH PRIVATE KEY-----",
 				},
 				ContainerRegistries: []generator.ContainerRegistry{
 					{

--- a/cmd/template_lagoonservices_test.go
+++ b/cmd/template_lagoonservices_test.go
@@ -283,21 +283,48 @@ func TestTemplateLagoonServices(t *testing.T) {
 			templatePath: "testoutput",
 			want:         "internal/testdata/complex/service-templates/service4",
 		},
-		{
-			name: "test10 basic deployment polysite cronjobs",
-			args: testdata.GetSeedData(
-				testdata.TestData{
-					ProjectName:     "example-project",
-					EnvironmentName: "main",
-					Branch:          "main",
-					LagoonYAML:      "internal/testdata/basic/lagoon.polysite-cronjobs.yml",
-					ImageReferences: map[string]string{
-						"node": "harbor.example/example-project/main/node@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8",
-					},
-				}, true),
-			templatePath: "testoutput",
-			want:         "internal/testdata/basic/service-templates/service7",
-		},
+		// {
+		// 	name: "test11 basic deployment pullthrough image",
+		// 	args: testdata.GetSeedData(
+		// 		testdata.TestData{
+		// 			ProjectName:     "example-project",
+		// 			EnvironmentName: "main",
+		// 			Branch:          "main",
+		// 			LagoonYAML:      "internal/testdata/basic/lagoon.container-registry-deep-pulltrough.yml",
+		// 			ImageReferences: map[string]string{
+		// 				"node": "harbor.example/example-project/main/node@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8",
+		// 			},
+		// 			ProjectVariables: []lagoon.EnvironmentVariable{
+		// 				{
+		// 					Name:  "REGISTRY_PASSWORD",
+		// 					Value: "myenvvarregistrypassword",
+		// 					Scope: "container_registry",
+		// 				},
+		// 				{
+		// 					Name:  "REGISTRY_DOCKERHUB_USERNAME",
+		// 					Value: "dockerhubusername",
+		// 					Scope: "container_registry",
+		// 				},
+		// 				{
+		// 					Name:  "REGISTRY_DOCKERHUB_PASSWORD",
+		// 					Value: "dockerhubpassword",
+		// 					Scope: "container_registry",
+		// 				},
+		// 				{
+		// 					Name:  "REGISTRY_MY_OTHER_REGISTRY_USERNAME",
+		// 					Value: "otherusername",
+		// 					Scope: "container_registry",
+		// 				},
+		// 				{
+		// 					Name:  "REGISTRY_MY_OTHER_REGISTRY_PASSWORD",
+		// 					Value: "otherpassword",
+		// 					Scope: "container_registry",
+		// 				},
+		// 			},
+		// 		}, true),
+		// 	templatePath: "testoutput",
+		// 	want:         "internal/testdata/basic/service-templates/service8",
+		// },
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/template_lagoonservices_test.go
+++ b/cmd/template_lagoonservices_test.go
@@ -283,48 +283,6 @@ func TestTemplateLagoonServices(t *testing.T) {
 			templatePath: "testoutput",
 			want:         "internal/testdata/complex/service-templates/service4",
 		},
-		// {
-		// 	name: "test11 basic deployment pullthrough image",
-		// 	args: testdata.GetSeedData(
-		// 		testdata.TestData{
-		// 			ProjectName:     "example-project",
-		// 			EnvironmentName: "main",
-		// 			Branch:          "main",
-		// 			LagoonYAML:      "internal/testdata/basic/lagoon.container-registry-deep-pulltrough.yml",
-		// 			ImageReferences: map[string]string{
-		// 				"node": "harbor.example/example-project/main/node@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8",
-		// 			},
-		// 			ProjectVariables: []lagoon.EnvironmentVariable{
-		// 				{
-		// 					Name:  "REGISTRY_PASSWORD",
-		// 					Value: "myenvvarregistrypassword",
-		// 					Scope: "container_registry",
-		// 				},
-		// 				{
-		// 					Name:  "REGISTRY_DOCKERHUB_USERNAME",
-		// 					Value: "dockerhubusername",
-		// 					Scope: "container_registry",
-		// 				},
-		// 				{
-		// 					Name:  "REGISTRY_DOCKERHUB_PASSWORD",
-		// 					Value: "dockerhubpassword",
-		// 					Scope: "container_registry",
-		// 				},
-		// 				{
-		// 					Name:  "REGISTRY_MY_OTHER_REGISTRY_USERNAME",
-		// 					Value: "otherusername",
-		// 					Scope: "container_registry",
-		// 				},
-		// 				{
-		// 					Name:  "REGISTRY_MY_OTHER_REGISTRY_PASSWORD",
-		// 					Value: "otherpassword",
-		// 					Scope: "container_registry",
-		// 				},
-		// 			},
-		// 		}, true),
-		// 	templatePath: "testoutput",
-		// 	want:         "internal/testdata/basic/service-templates/service8",
-		// },
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/template_lagoonservices_test.go
+++ b/cmd/template_lagoonservices_test.go
@@ -127,6 +127,32 @@ func TestTemplateLagoonServices(t *testing.T) {
 			want:         "internal/testdata/complex/service-templates/service2",
 		},
 		{
+			name: "test2b nginx-php deployment - rootless workloads enabled",
+			args: testdata.GetSeedData(
+				testdata.TestData{
+					ProjectName:     "example-project",
+					EnvironmentName: "main",
+					Branch:          "main",
+					LagoonYAML:      "internal/testdata/complex/lagoon.varnish.yml",
+					ImageReferences: map[string]string{
+						"nginx":   "harbor.example/example-project/main/nginx@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8",
+						"php":     "harbor.example/example-project/main/php@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8",
+						"cli":     "harbor.example/example-project/main/cli@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8",
+						"redis":   "harbor.example/example-project/main/redis@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8",
+						"varnish": "harbor.example/example-project/main/varnish@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8",
+					},
+					ProjectVariables: []lagoon.EnvironmentVariable{
+						{
+							Name:  "LAGOON_FEATURE_FLAG_ROOTLESS_WORKLOAD",
+							Value: "enabled",
+							Scope: "build",
+						},
+					},
+				}, true),
+			templatePath: "testoutput",
+			want:         "internal/testdata/complex/service-templates/service5",
+		},
+		{
 			name:        "test3 - funky pvcs",
 			description: "only create pvcs of the requested persistent-name in the docker-compose file",
 			args: testdata.GetSeedData(

--- a/internal/generator/build_data.go
+++ b/internal/generator/build_data.go
@@ -85,5 +85,6 @@ func collectImageBuildArguments(buildValues BuildValues) map[string]string {
 	for _, icba := range buildValues.ImageCacheBuildArguments {
 		buildArgs[fmt.Sprintf("LAGOON_CACHE_%s", icba.Name)] = icba.Image
 	}
+	buildArgs["LAGOON_SSH_PRIVATE_KEY"] = buildValues.SSHPrivateKey
 	return buildArgs
 }

--- a/internal/generator/buildvalues.go
+++ b/internal/generator/buildvalues.go
@@ -78,6 +78,7 @@ type BuildValues struct {
 	BackupsEnabled                bool                         `json:"backupsEnabled"`
 	RouteQuota                    *int                         `json:"routeQuota"`
 	ImageCacheBuildArguments      []ImageCacheBuildArguments   `json:"imageCacheBuildArgs"`
+	IgnoreImageCache              bool                         `json:"ignoreImageCache"`
 }
 
 type Resources struct {

--- a/internal/generator/buildvalues.go
+++ b/internal/generator/buildvalues.go
@@ -79,6 +79,7 @@ type BuildValues struct {
 	RouteQuota                    *int                         `json:"routeQuota"`
 	ImageCacheBuildArguments      []ImageCacheBuildArguments   `json:"imageCacheBuildArgs"`
 	IgnoreImageCache              bool                         `json:"ignoreImageCache"`
+	SSHPrivateKey                 string                       `json:"sshPrivateKey"`
 }
 
 type Resources struct {

--- a/internal/generator/container_registries.go
+++ b/internal/generator/container_registries.go
@@ -68,6 +68,7 @@ func configureContainerRegistries(buildValues *BuildValues) error {
 		}
 		if cr.URL == "" {
 			cr.URL = "index.docker.io"
+			buildValues.IgnoreImageCache = true
 		}
 		eru := cr.URL
 		u, _ := url.Parse(eru)

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -65,6 +65,7 @@ type GeneratorInput struct {
 	DynamicSecrets             []string
 	DynamicDBaaSSecrets        []string
 	ImageCacheBuildArgsJSON    string
+	SSHPrivateKey              string
 }
 
 func NewGenerator(
@@ -110,6 +111,7 @@ func NewGenerator(
 	dynamicSecrets := helpers.GetEnv("DYNAMIC_SECRETS", strings.Join(generator.DynamicSecrets, ","), generator.Debug)
 	dynamicDBaaSSecrets := helpers.GetEnv("DYNAMIC_DBAAS_SECRETS", strings.Join(generator.DynamicDBaaSSecrets, ","), generator.Debug)
 	imageCacheBuildArgsJSON := helpers.GetEnv("LAGOON_CACHE_BUILD_ARGS", generator.ImageCacheBuildArgsJSON, generator.Debug)
+	buildValues.SSHPrivateKey = helpers.GetEnv("SSH_PRIVATE_KEY", generator.SSHPrivateKey, generator.Debug)
 	// this is used by CI systems to influence builds, it is rarely used and should probably be abandoned
 	buildValues.IsCI = helpers.GetEnvBool("CI", generator.CI, generator.Debug)
 

--- a/internal/generator/services.go
+++ b/internal/generator/services.go
@@ -532,7 +532,7 @@ func composeToServiceValues(
 					}
 					if !ContainsRegistry(buildValues.ContainerRegistry, pullImage) {
 						// if the image isn't in dockerhub, then the imagecache can't be used
-						if buildValues.ImageCache != "" && strings.Count(pullImage, "/") == 1 {
+						if buildValues.ImageCache != "" && strings.Count(pullImage, "/") == 1 && !buildValues.IgnoreImageCache {
 							imageBuild.PullImage = fmt.Sprintf("%s%s", buildValues.ImageCache, imageBuild.PullImage)
 						}
 					}

--- a/internal/helpers/helpers_cron.go
+++ b/internal/helpers/helpers_cron.go
@@ -16,7 +16,7 @@ func ConvertCrontab(namespace, cron string) (string, error) {
 	// namespace, so will not change after a deployment for a given namespace.
 	seed := cksum.Cksum([]byte(fmt.Sprintf("%s\n", namespace)))
 	var minutes, hours, days, months, dayweek string
-	splitCron := strings.Split(cron, " ")
+	splitCron := strings.Split(strings.Trim(cron, " "), " ")
 	// check the provided cron splits into 5
 	if len(splitCron) == 5 {
 		for idx, val := range splitCron {

--- a/internal/helpers/helpers_cron.go
+++ b/internal/helpers/helpers_cron.go
@@ -215,6 +215,9 @@ func ConvertCrontab(namespace, cron string) (string, error) {
 		}
 		return fmt.Sprintf("%v %v %v %v %v", minutes, hours, days, months, dayweek), nil
 	}
+	if len(splitCron) < 5 && len(splitCron) > 0 || len(splitCron) > 5 {
+		return "", fmt.Errorf("cron definition '%s' is invalid, %d fields provided, required 5", cron, len(splitCron))
+	}
 	return "", fmt.Errorf("cron definition '%s' is invalid", cron)
 }
 

--- a/internal/helpers/helpers_cron_test.go
+++ b/internal/helpers/helpers_cron_test.go
@@ -159,6 +159,14 @@ func TestConvertCrontab(t *testing.T) {
 			},
 			want: "31 1,7,13,19 * JAN MON",
 		},
+		{
+			name: "test19 - whitespace",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "M * * * * ",
+			},
+			want: "31 * * * *",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/servicetypes/elasticsearch.go
+++ b/internal/servicetypes/elasticsearch.go
@@ -93,6 +93,10 @@ fi`,
 			},
 		},
 	},
+	PodSecurityContext: ServicePodSecurityContext{
+		HasDefault: true,
+		FSGroup:    0,
+	},
 	Strategy: appsv1.DeploymentStrategy{
 		Type: appsv1.RecreateDeploymentStrategyType,
 	},

--- a/internal/servicetypes/solr.go
+++ b/internal/servicetypes/solr.go
@@ -71,6 +71,10 @@ var solr = ServiceType{
 			},
 		},
 	},
+	PodSecurityContext: ServicePodSecurityContext{
+		HasDefault: true,
+		FSGroup:    0,
+	},
 	Strategy: appsv1.DeploymentStrategy{
 		Type: appsv1.RecreateDeploymentStrategyType,
 	},

--- a/internal/templating/services/templates_cronjob.go
+++ b/internal/templating/services/templates_cronjob.go
@@ -205,6 +205,12 @@ func GenerateCronjobTemplate(
 						FSGroup:    helpers.Int64Ptr(buildValues.PodSecurityContext.FsGroup),
 					}
 				}
+				// some services have a fsgroup override
+				if serviceTypeValues.PodSecurityContext.HasDefault {
+					cronjob.Spec.JobTemplate.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+						FSGroup: helpers.Int64Ptr(serviceTypeValues.PodSecurityContext.FSGroup),
+					}
+				}
 				if buildValues.PodSecurityContext.OnRootMismatch {
 					fsGroupChangePolicy := corev1.FSGroupChangeOnRootMismatch
 					if cronjob.Spec.JobTemplate.Spec.Template.Spec.SecurityContext != nil {

--- a/internal/templating/services/templates_cronjob.go
+++ b/internal/templating/services/templates_cronjob.go
@@ -72,12 +72,20 @@ func GenerateCronjobTemplate(
 					serviceValues,
 					serviceTypeValues,
 				}
-				if serviceTypeValues.Volumes.BackupConfiguration.Command != "" {
-					bc := servicetypes.BackupConfiguration{}
-					helpers.TemplateThings(tpld, serviceTypeValues.Volumes.BackupConfiguration, &bc)
-					templateAnnotations["k8up.syn.tools/backupcommand"] = bc.Command
-					templateAnnotations["k8up.syn.tools/file-extension"] = bc.FileExtension
-				}
+
+				// cronjobs don't need backups
+				// if serviceTypeValues.Volumes.BackupConfiguration.Command != "" {
+				// 	bc := servicetypes.BackupConfiguration{}
+				// 	helpers.TemplateThings(tpld, serviceTypeValues.Volumes.BackupConfiguration, &bc)
+				// 	switch buildValues.Backup.K8upVersion {
+				// 	case "v2":
+				// 		templateAnnotations["k8up.io/backupcommand"] = bc.Command
+				// 		templateAnnotations["k8up.io/file-extension"] = bc.FileExtension
+				// 	default:
+				// 		templateAnnotations["k8up.syn.tools/backupcommand"] = bc.Command
+				// 		templateAnnotations["k8up.syn.tools/file-extension"] = bc.FileExtension
+				// 	}
+				// }
 
 				cronjob := &batchv1.CronJob{
 					TypeMeta: metav1.TypeMeta{

--- a/internal/templating/services/templates_deployment.go
+++ b/internal/templating/services/templates_deployment.go
@@ -202,6 +202,12 @@ func GenerateDeploymentTemplate(
 					FSGroup:    helpers.Int64Ptr(buildValues.PodSecurityContext.FsGroup),
 				}
 			}
+			// some services have a fsgroup override
+			if serviceTypeValues.PodSecurityContext.HasDefault {
+				deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+					FSGroup: helpers.Int64Ptr(serviceTypeValues.PodSecurityContext.FSGroup),
+				}
+			}
 			if buildValues.PodSecurityContext.OnRootMismatch {
 				fsGroupChangePolicy := corev1.FSGroupChangeOnRootMismatch
 				if deployment.Spec.Template.Spec.SecurityContext != nil {

--- a/internal/templating/services/templates_deployment.go
+++ b/internal/templating/services/templates_deployment.go
@@ -75,8 +75,14 @@ func GenerateDeploymentTemplate(
 			if serviceTypeValues.Volumes.BackupConfiguration.Command != "" {
 				bc := servicetypes.BackupConfiguration{}
 				helpers.TemplateThings(tpld, serviceTypeValues.Volumes.BackupConfiguration, &bc)
-				templateAnnotations["k8up.syn.tools/backupcommand"] = bc.Command
-				templateAnnotations["k8up.syn.tools/file-extension"] = bc.FileExtension
+				switch buildValues.Backup.K8upVersion {
+				case "v2":
+					templateAnnotations["k8up.io/backupcommand"] = bc.Command
+					templateAnnotations["k8up.io/file-extension"] = bc.FileExtension
+				default:
+					templateAnnotations["k8up.syn.tools/backupcommand"] = bc.Command
+					templateAnnotations["k8up.syn.tools/file-extension"] = bc.FileExtension
+				}
 			}
 
 			// create the initial deployment spec

--- a/internal/templating/services/templates_deployment_test.go
+++ b/internal/templating/services/templates_deployment_test.go
@@ -226,9 +226,12 @@ func TestGenerateDeploymentTemplate(t *testing.T) {
 					BuildType:       "branch",
 					LagoonVersion:   "v2.x.x",
 					Kubernetes:      "generator.local",
-					Branch:          "environment-name",
-					GitSHA:          "0",
-					ConfigMapSha:    "32bf1359ac92178c8909f0ef938257b477708aa0d78a5a15ad7c2d7919adf273",
+					PodSecurityContext: generator.PodSecurityContext{
+						OnRootMismatch: true,
+					},
+					Branch:       "environment-name",
+					GitSHA:       "0",
+					ConfigMapSha: "32bf1359ac92178c8909f0ef938257b477708aa0d78a5a15ad7c2d7919adf273",
 					ImageReferences: map[string]string{
 						"myservice": "harbor.example.com/example-project/environment-name/myservice@latest",
 					},
@@ -255,9 +258,12 @@ func TestGenerateDeploymentTemplate(t *testing.T) {
 					BuildType:       "branch",
 					LagoonVersion:   "v2.x.x",
 					Kubernetes:      "generator.local",
-					Branch:          "environment-name",
-					GitSHA:          "0",
-					ConfigMapSha:    "32bf1359ac92178c8909f0ef938257b477708aa0d78a5a15ad7c2d7919adf273",
+					PodSecurityContext: generator.PodSecurityContext{
+						OnRootMismatch: true,
+					},
+					Branch:       "environment-name",
+					GitSHA:       "0",
+					ConfigMapSha: "32bf1359ac92178c8909f0ef938257b477708aa0d78a5a15ad7c2d7919adf273",
 					ImageReferences: map[string]string{
 						"myservice":      "harbor.example.com/example-project/environment-name/myservice@latest",
 						"myservice-size": "harbor.example.com/example-project/environment-name/myservice-size@latest",
@@ -293,9 +299,12 @@ func TestGenerateDeploymentTemplate(t *testing.T) {
 					BuildType:       "branch",
 					LagoonVersion:   "v2.x.x",
 					Kubernetes:      "generator.local",
-					Branch:          "environment-name",
-					GitSHA:          "0",
-					ConfigMapSha:    "32bf1359ac92178c8909f0ef938257b477708aa0d78a5a15ad7c2d7919adf273",
+					PodSecurityContext: generator.PodSecurityContext{
+						OnRootMismatch: true,
+					},
+					Branch:       "environment-name",
+					GitSHA:       "0",
+					ConfigMapSha: "32bf1359ac92178c8909f0ef938257b477708aa0d78a5a15ad7c2d7919adf273",
 					ImageReferences: map[string]string{
 						"myservice":      "harbor.example.com/example-project/environment-name/myservice@latest",
 						"myservice-size": "harbor.example.com/example-project/environment-name/myservice-size@latest",
@@ -378,9 +387,12 @@ func TestGenerateDeploymentTemplate(t *testing.T) {
 					BuildType:       "branch",
 					LagoonVersion:   "v2.x.x",
 					Kubernetes:      "generator.local",
-					Branch:          "environment-name",
-					GitSHA:          "0",
-					ConfigMapSha:    "32bf1359ac92178c8909f0ef938257b477708aa0d78a5a15ad7c2d7919adf273",
+					PodSecurityContext: generator.PodSecurityContext{
+						OnRootMismatch: true,
+					},
+					Branch:       "environment-name",
+					GitSHA:       "0",
+					ConfigMapSha: "32bf1359ac92178c8909f0ef938257b477708aa0d78a5a15ad7c2d7919adf273",
 					ImageReferences: map[string]string{
 						"solr": "harbor.example.com/example-project/environment-name/solr@latest",
 					},
@@ -730,9 +742,6 @@ func TestGenerateDeploymentTemplate(t *testing.T) {
 					Kubernetes:      "generator.local",
 					Branch:          "environment-name",
 					PodSecurityContext: generator.PodSecurityContext{
-						RunAsGroup:     0,
-						RunAsUser:      10000,
-						FsGroup:        10001,
 						OnRootMismatch: true,
 					},
 					GitSHA:       "0",
@@ -764,9 +773,6 @@ func TestGenerateDeploymentTemplate(t *testing.T) {
 					Kubernetes:      "generator.local",
 					Branch:          "environment-name",
 					PodSecurityContext: generator.PodSecurityContext{
-						RunAsGroup:     0,
-						RunAsUser:      10000,
-						FsGroup:        10001,
 						OnRootMismatch: true,
 					},
 					GitSHA:       "0",
@@ -798,9 +804,6 @@ func TestGenerateDeploymentTemplate(t *testing.T) {
 					Kubernetes:      "generator.local",
 					Branch:          "environment-name",
 					PodSecurityContext: generator.PodSecurityContext{
-						RunAsGroup:     0,
-						RunAsUser:      10000,
-						FsGroup:        10001,
 						OnRootMismatch: true,
 					},
 					GitSHA:       "0",

--- a/internal/templating/services/templates_deployment_test.go
+++ b/internal/templating/services/templates_deployment_test.go
@@ -730,7 +730,7 @@ func TestGenerateDeploymentTemplate(t *testing.T) {
 			want: "test-resources/deployment/result-redis-1.yaml",
 		},
 		{
-			name: "test17 - mariadb",
+			name: "test17a - mariadb",
 			args: args{
 				buildValues: generator.BuildValues{
 					Project:         "example-project",
@@ -759,6 +759,40 @@ func TestGenerateDeploymentTemplate(t *testing.T) {
 				},
 			},
 			want: "test-resources/deployment/result-mariadb-1.yaml",
+		},
+		{
+			name: "test17b - mariadb k8upv2",
+			args: args{
+				buildValues: generator.BuildValues{
+					Project:         "example-project",
+					Environment:     "environment-name",
+					EnvironmentType: "production",
+					Namespace:       "example-project-environment-name",
+					BuildType:       "branch",
+					LagoonVersion:   "v2.x.x",
+					Kubernetes:      "generator.local",
+					Branch:          "environment-name",
+					PodSecurityContext: generator.PodSecurityContext{
+						OnRootMismatch: true,
+					},
+					GitSHA:       "0",
+					ConfigMapSha: "32bf1359ac92178c8909f0ef938257b477708aa0d78a5a15ad7c2d7919adf273",
+					ImageReferences: map[string]string{
+						"mariadb": "harbor.example.com/example-project/environment-name/mariadb@latest",
+					},
+					Backup: generator.BackupConfiguration{
+						K8upVersion: "v2",
+					},
+					Services: []generator.ServiceValues{
+						{
+							Name:         "mariadb",
+							OverrideName: "mariadb",
+							Type:         "mariadb-single",
+						},
+					},
+				},
+			},
+			want: "test-resources/deployment/result-mariadb-2.yaml",
 		},
 		{
 			name: "test18 - mongodb",

--- a/internal/templating/services/templates_pvc.go
+++ b/internal/templating/services/templates_pvc.go
@@ -77,6 +77,7 @@ func GeneratePVCTemplate(
 				additionalLabels["lagoon.sh/service"] = serviceValues.OverrideName
 				additionalLabels["lagoon.sh/service-type"] = serviceType.Name
 
+				// this does both k8up v1 and v2 support
 				additionalAnnotations["k8up.syn.tools/backup"] = strconv.FormatBool(serviceTypeValues.Volumes.Backup)
 				additionalAnnotations["k8up.io/backup"] = strconv.FormatBool(serviceTypeValues.Volumes.Backup)
 

--- a/internal/templating/services/test-resources/deployment/result-elasticsearch-1.yaml
+++ b/internal/templating/services/test-resources/deployment/result-elasticsearch-1.yaml
@@ -105,6 +105,9 @@ spec:
           privileged: true
           runAsUser: 0
       priorityClassName: lagoon-priority-production
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
       volumes:
       - name: myservice
         persistentVolumeClaim:
@@ -217,6 +220,9 @@ spec:
           privileged: true
           runAsUser: 0
       priorityClassName: lagoon-priority-production
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
       volumes:
       - name: myservice-size
         persistentVolumeClaim:

--- a/internal/templating/services/test-resources/deployment/result-mariadb-1.yaml
+++ b/internal/templating/services/test-resources/deployment/result-mariadb-1.yaml
@@ -89,10 +89,8 @@ spec:
       - name: lagoon-internal-registry-secret
       priorityClassName: lagoon-priority-production
       securityContext:
-        fsGroup: 10001
+        fsGroup: 0
         fsGroupChangePolicy: OnRootMismatch
-        runAsGroup: 0
-        runAsUser: 10000
       volumes:
       - name: mariadb
         persistentVolumeClaim:

--- a/internal/templating/services/test-resources/deployment/result-mariadb-2.yaml
+++ b/internal/templating/services/test-resources/deployment/result-mariadb-2.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    lagoon.sh/branch: environment-name
+    lagoon.sh/version: v2.x.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: mariadb
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: mariadb-single
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: environment-name
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: mariadb
+    lagoon.sh/service-type: mariadb-single
+    lagoon.sh/template: mariadb-single-0.1.0
+  name: mariadb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: mariadb
+      app.kubernetes.io/name: mariadb-single
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        k8up.io/backupcommand: /bin/sh -c 'mysqldump --max-allowed-packet=1G --events
+          --routines --quick --add-locks --no-autocommit --single-transaction --all-databases'
+        k8up.io/file-extension: .mariadb.sql
+        lagoon.sh/branch: environment-name
+        lagoon.sh/configMapSha: 32bf1359ac92178c8909f0ef938257b477708aa0d78a5a15ad7c2d7919adf273
+        lagoon.sh/version: v2.x.x
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: mariadb
+        app.kubernetes.io/managed-by: build-deploy-tool
+        app.kubernetes.io/name: mariadb-single
+        lagoon.sh/buildType: branch
+        lagoon.sh/environment: environment-name
+        lagoon.sh/environmentType: production
+        lagoon.sh/project: example-project
+        lagoon.sh/service: mariadb
+        lagoon.sh/service-type: mariadb-single
+        lagoon.sh/template: mariadb-single-0.1.0
+    spec:
+      containers:
+      - env:
+        - name: LAGOON_GIT_SHA
+          value: "0"
+        - name: CRONJOBS
+        - name: SERVICE_NAME
+          value: mariadb
+        envFrom:
+        - configMapRef:
+            name: lagoon-env
+        image: harbor.example.com/example-project/environment-name/mariadb@latest
+        imagePullPolicy: Always
+        livenessProbe:
+          initialDelaySeconds: 120
+          periodSeconds: 5
+          tcpSocket:
+            port: 3306
+        name: mariadb-single
+        ports:
+        - containerPort: 3306
+          name: 3306-tcp
+          protocol: TCP
+        readinessProbe:
+          initialDelaySeconds: 1
+          tcpSocket:
+            port: 3306
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext: {}
+        volumeMounts:
+        - mountPath: /var/lib/mysql
+          name: mariadb
+      enableServiceLinks: true
+      imagePullSecrets:
+      - name: lagoon-internal-registry-secret
+      priorityClassName: lagoon-priority-production
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+      volumes:
+      - name: mariadb
+        persistentVolumeClaim:
+          claimName: mariadb
+status: {}

--- a/internal/templating/services/test-resources/deployment/result-mongodb-1.yaml
+++ b/internal/templating/services/test-resources/deployment/result-mongodb-1.yaml
@@ -88,10 +88,8 @@ spec:
       - name: lagoon-internal-registry-secret
       priorityClassName: lagoon-priority-production
       securityContext:
-        fsGroup: 10001
+        fsGroup: 0
         fsGroupChangePolicy: OnRootMismatch
-        runAsGroup: 0
-        runAsUser: 10000
       volumes:
       - name: mongodb
         persistentVolumeClaim:

--- a/internal/templating/services/test-resources/deployment/result-opensearch-1.yaml
+++ b/internal/templating/services/test-resources/deployment/result-opensearch-1.yaml
@@ -105,6 +105,9 @@ spec:
           privileged: true
           runAsUser: 0
       priorityClassName: lagoon-priority-production
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
       volumes:
       - name: myservice
         persistentVolumeClaim:
@@ -217,6 +220,9 @@ spec:
           privileged: true
           runAsUser: 0
       priorityClassName: lagoon-priority-production
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
       volumes:
       - name: myservice-size
         persistentVolumeClaim:

--- a/internal/templating/services/test-resources/deployment/result-postgres-1.yaml
+++ b/internal/templating/services/test-resources/deployment/result-postgres-1.yaml
@@ -89,10 +89,8 @@ spec:
       - name: lagoon-internal-registry-secret
       priorityClassName: lagoon-priority-production
       securityContext:
-        fsGroup: 10001
+        fsGroup: 0
         fsGroupChangePolicy: OnRootMismatch
-        runAsGroup: 0
-        runAsUser: 10000
       volumes:
       - name: postgres
         persistentVolumeClaim:

--- a/internal/templating/services/test-resources/deployment/result-postgres-single-1.yaml
+++ b/internal/templating/services/test-resources/deployment/result-postgres-single-1.yaml
@@ -88,6 +88,9 @@ spec:
       imagePullSecrets:
       - name: lagoon-internal-registry-secret
       priorityClassName: lagoon-priority-production
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
       volumes:
       - name: myservice
         persistentVolumeClaim:

--- a/internal/templating/services/test-resources/deployment/result-solr-1.yaml
+++ b/internal/templating/services/test-resources/deployment/result-solr-1.yaml
@@ -88,6 +88,9 @@ spec:
       imagePullSecrets:
       - name: lagoon-internal-registry-secret
       priorityClassName: lagoon-priority-production
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
       volumes:
       - name: solr
         persistentVolumeClaim:

--- a/internal/testdata/complex/docker-compose.varnish3.yml
+++ b/internal/testdata/complex/docker-compose.varnish3.yml
@@ -1,0 +1,160 @@
+version: '2.3'
+
+x-example-image-version:
+  &example-image-version ${EXAMPLE_IMAGE_VERSION:-4.x}
+
+x-project:
+  &project ${PROJECT_NAME:-mysite}
+
+x-volumes:
+  &default-volumes
+  volumes:
+    - .:/app:${VOLUME_FLAGS:-delegated} ### Local overrides to mount host filesystem. Automatically removed in CI and PROD.
+    - ./docroot/sites/default/files:/app/docroot/sites/default/files:${VOLUME_FLAGS:-delegated} ### Local overrides to mount host filesystem. Automatically removed in CI and PROD.
+
+x-environment:
+  &default-environment
+  LAGOON_PROJECT: *project
+  DRUPAL_HASH_SALT: fakehashsaltfakehashsaltfakehashsalt
+  LAGOON_LOCALDEV_URL: ${LOCALDEV_URL:-http://mysite.docker.amazee.io}
+  LAGOON_ROUTE: ${LOCALDEV_URL:-http://mysite.docker.amazee.io}
+  GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+  EXAMPLE_KEY: ${EXAMPLE_KEY:-}
+  EXAMPLE_IMAGE_VERSION: ${EXAMPLE_IMAGE_VERSION:-latest}
+  LAGOON_ENVIRONMENT_TYPE: ${LAGOON_ENVIRONMENT_TYPE:-local}
+  DRUPAL_REFRESH_SEARCHAPI: ${DRUPAL_REFRESH_SEARCHAPI:-}
+  EXAMPLE_INGRESS_PSK: ${EXAMPLE_INGRESS_PSK:-}
+  EXAMPLE_INGRESS_HEADER: ${EXAMPLE_INGRESS_HEADER:-}
+  EXAMPLE_INGRESS_ENABLED: ${EXAMPLE_INGRESS_ENABLED:-}
+  REDIS_CACHE_PREFIX: "tide_"
+  DB_ALIAS: ${DB_ALIAS:-bay.production}
+
+
+services:
+
+  cli:
+    build:
+      context: internal/testdata/complex/docker
+      dockerfile: .docker/Dockerfile.cli
+      args:
+        COMPOSER: ${COMPOSER:-composer.json}
+        EXAMPLE_IMAGE_VERSION: *example-image-version
+    image: *project
+    environment:
+      << : *default-environment
+    << : *default-volumes
+    volumes_from: ### Local overrides to mount host SSH keys. Automatically removed in CI.
+      - container:amazeeio-ssh-agent ### Local overrides to mount host SSH keys. Automatically removed in CI.
+    labels:
+      lagoon.type: cli-persistent
+      lagoon.persistent: /app/docroot/sites/default/files/
+      lagoon.persistent.name: nginx-php
+      lagoon.persistent.size: 5Gi
+
+  nginx:
+    build:
+      context: internal/testdata/complex/docker
+      dockerfile: .docker/Dockerfile.nginx-drupal
+      args:
+        CLI_IMAGE: *project
+        EXAMPLE_IMAGE_VERSION: *example-image-version
+    << : *default-volumes
+    environment:
+      << : *default-environment
+    depends_on:
+      - cli
+    networks:
+      - amazeeio-network
+      - default
+    labels:
+      lagoon.type: nginx-php-persistent
+      lagoon.persistent: /app/docroot/sites/default/files/
+      lagoon.persistent.size: 5Gi
+      lagoon.name: nginx-php
+    expose:
+      - "8080"
+  php:
+    build:
+      context: internal/testdata/complex/docker
+      dockerfile: .docker/Dockerfile.php
+      args:
+        CLI_IMAGE: *project
+        EXAMPLE_IMAGE_VERSION: *example-image-version
+    environment:
+      << : *default-environment
+    << : *default-volumes
+    depends_on:
+      - cli
+    labels:
+      lagoon.type: nginx-php-persistent
+      lagoon.persistent: /app/docroot/sites/default/files/
+      lagoon.persistent.size: 5Gi
+      lagoon.name: nginx-php
+
+  mariadb:
+    image: amazeeio/mariadb-drupal
+    environment:
+      << : *default-environment
+    ports:
+      - "3306" # Find port on host with `ahoy info` or `docker-compose port mariadb 3306`
+    labels:
+      lagoon.type: mariadb
+
+  redis:
+    image: registry1.example.com/amazeeio/redis:latest
+    labels:
+      lagoon.type: redis
+
+  elasticsearch:
+    build:
+      context: internal/testdata/complex/docker
+      dockerfile: .docker/Dockerfile.elasticsearch
+      args:
+        - ES_TPL=${ES_TPL:-elasticsearch.yml}
+    environment:
+      - discovery.type=single-node
+    labels:
+      lagoon.type: none
+
+  chrome:
+    image: selenium/standalone-chrome:3.141.59-oxygen
+    shm_size: '1gb'
+    environment:
+      << : *default-environment
+    << : *default-volumes
+    depends_on:
+      - cli
+    labels:
+      lagoon.type: none
+
+  clamav:
+    image: clamav/clamav:${EXAMPLE_IMAGE_VERSION:-4.x}
+    environment:
+      << : *default-environment
+    ports:
+      - "3310"
+    labels:
+      lagoon.type: none
+
+  varnish:
+    image: uselagoon/varnish-5-drupal:latest
+    labels:
+      lagoon.type: varnish
+      lando.type: varnish-drupal
+    links:
+      - nginx # links varnish to the nginx in this docker-compose project, or it would try to connect to any nginx running in docker
+    environment:
+      << : *default-environment
+      VARNISH_BYPASS: "true" # by default we bypass varnish, change to 'false' or remove in order to tell varnish to cache if possible
+    networks:
+      - amazeeio-network
+      - default
+
+
+networks:
+  amazeeio-network:
+    external: true
+
+volumes:
+  app: {}
+  files: {}

--- a/internal/testdata/complex/lagoon.varnish3.yml
+++ b/internal/testdata/complex/lagoon.varnish3.yml
@@ -1,0 +1,28 @@
+---
+docker-compose-yaml: internal/testdata/complex/docker-compose.varnish3.yml
+
+project: example-com
+
+container-registries:
+  my-custom-registry:
+    username: registry_user
+    password: REGISTRY_PASSWORD
+  my-other-custom-registry:
+    username: registry_user2
+    password: REGISTRY_PASSWORD2
+    url: registry1.example.com
+
+environments:
+  main:
+    routes:
+      - nginx:
+          - example.com
+    cronjobs:
+      - name: drush cron
+        schedule: "*/15 * * * *"
+        command: drush cron
+        service: cli
+      - name: drush cron2
+        schedule: "*/30 * * * *"
+        command: drush cron
+        service: cli

--- a/internal/testdata/complex/service-templates/service3/deployment-mariadb-10-5.yaml
+++ b/internal/testdata/complex/service-templates/service3/deployment-mariadb-10-5.yaml
@@ -88,6 +88,8 @@ spec:
       imagePullSecrets:
       - name: lagoon-internal-registry-secret
       priorityClassName: lagoon-priority-production
+      securityContext:
+        fsGroup: 0
       volumes:
       - name: mariadb-10-5
         persistentVolumeClaim:

--- a/internal/testdata/complex/service-templates/service3/deployment-opensearch-2.yaml
+++ b/internal/testdata/complex/service-templates/service3/deployment-opensearch-2.yaml
@@ -105,6 +105,8 @@ spec:
           privileged: true
           runAsUser: 0
       priorityClassName: lagoon-priority-production
+      securityContext:
+        fsGroup: 0
       volumes:
       - name: opensearch-2
         persistentVolumeClaim:

--- a/internal/testdata/complex/service-templates/service3/deployment-postgres-11.yaml
+++ b/internal/testdata/complex/service-templates/service3/deployment-postgres-11.yaml
@@ -88,6 +88,8 @@ spec:
       imagePullSecrets:
       - name: lagoon-internal-registry-secret
       priorityClassName: lagoon-priority-production
+      securityContext:
+        fsGroup: 0
       volumes:
       - name: postgres-11
         persistentVolumeClaim:

--- a/internal/testdata/complex/service-templates/service3/deployment-solr-8.yaml
+++ b/internal/testdata/complex/service-templates/service3/deployment-solr-8.yaml
@@ -88,6 +88,8 @@ spec:
       imagePullSecrets:
       - name: lagoon-internal-registry-secret
       priorityClassName: lagoon-priority-production
+      securityContext:
+        fsGroup: 0
       volumes:
       - name: solr-8
         persistentVolumeClaim:

--- a/internal/testdata/complex/service-templates/service4/deployment-mariadb-10-11.yaml
+++ b/internal/testdata/complex/service-templates/service4/deployment-mariadb-10-11.yaml
@@ -88,6 +88,8 @@ spec:
       imagePullSecrets:
       - name: lagoon-internal-registry-secret
       priorityClassName: lagoon-priority-production
+      securityContext:
+        fsGroup: 0
       volumes:
       - name: mariadb-10-11
         persistentVolumeClaim:

--- a/internal/testdata/complex/service-templates/service4/deployment-mariadb-10-5.yaml
+++ b/internal/testdata/complex/service-templates/service4/deployment-mariadb-10-5.yaml
@@ -88,6 +88,8 @@ spec:
       imagePullSecrets:
       - name: lagoon-internal-registry-secret
       priorityClassName: lagoon-priority-production
+      securityContext:
+        fsGroup: 0
       volumes:
       - name: mariadb-10-5
         persistentVolumeClaim:

--- a/internal/testdata/complex/service-templates/service4/deployment-mongo-4.yaml
+++ b/internal/testdata/complex/service-templates/service4/deployment-mongo-4.yaml
@@ -87,6 +87,8 @@ spec:
       imagePullSecrets:
       - name: lagoon-internal-registry-secret
       priorityClassName: lagoon-priority-production
+      securityContext:
+        fsGroup: 0
       volumes:
       - name: mongo-4
         persistentVolumeClaim:

--- a/internal/testdata/complex/service-templates/service4/deployment-postgres-11.yaml
+++ b/internal/testdata/complex/service-templates/service4/deployment-postgres-11.yaml
@@ -88,6 +88,8 @@ spec:
       imagePullSecrets:
       - name: lagoon-internal-registry-secret
       priorityClassName: lagoon-priority-production
+      securityContext:
+        fsGroup: 0
       volumes:
       - name: postgres-11
         persistentVolumeClaim:

--- a/internal/testdata/complex/service-templates/service4/deployment-postgres-15.yaml
+++ b/internal/testdata/complex/service-templates/service4/deployment-postgres-15.yaml
@@ -88,6 +88,8 @@ spec:
       imagePullSecrets:
       - name: lagoon-internal-registry-secret
       priorityClassName: lagoon-priority-production
+      securityContext:
+        fsGroup: 0
       volumes:
       - name: postgres-15
         persistentVolumeClaim:

--- a/internal/testdata/complex/service-templates/service5/cronjob-cronjob-cli-drush-cron2.yaml
+++ b/internal/testdata/complex/service-templates/service5/cronjob-cronjob-cli-drush-cron2.yaml
@@ -1,0 +1,99 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: build-deploy-tool
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: cli
+    lagoon.sh/service-type: cli-persistent
+    lagoon.sh/template: cli-persistent-0.1.0
+  name: cronjob-cli-drush-cron2
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          annotations:
+            lagoon.sh/branch: main
+            lagoon.sh/configMapSha: abcdefg1234567890
+            lagoon.sh/version: v2.7.x
+          creationTimestamp: null
+          labels:
+            app.kubernetes.io/managed-by: build-deploy-tool
+            lagoon.sh/buildType: branch
+            lagoon.sh/environment: main
+            lagoon.sh/environmentType: production
+            lagoon.sh/project: example-project
+            lagoon.sh/service: cli
+            lagoon.sh/service-type: cli-persistent
+            lagoon.sh/template: cli-persistent-0.1.0
+        spec:
+          containers:
+          - command:
+            - /lagoon/cronjob.sh
+            - drush cron
+            env:
+            - name: LAGOON_GIT_SHA
+              value: "0000000000000000000000000000000000000000"
+            - name: SERVICE_NAME
+              value: cli
+            envFrom:
+            - configMapRef:
+                name: lagoon-env
+            image: harbor.example/example-project/main/cli@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8
+            imagePullPolicy: Always
+            name: cronjob-cli-drush-cron2
+            resources:
+              requests:
+                cpu: 10m
+                memory: 10Mi
+            securityContext: {}
+            volumeMounts:
+            - mountPath: /var/run/secrets/lagoon/sshkey/
+              name: lagoon-sshkey
+              readOnly: true
+            - mountPath: /app/docroot/sites/default/files//php
+              name: nginx-php-twig
+            - mountPath: /app/docroot/sites/default/files/
+              name: nginx-php
+          dnsConfig:
+            options:
+            - name: timeout
+              value: "60"
+            - name: attempts
+              value: "10"
+          enableServiceLinks: false
+          imagePullSecrets:
+          - name: lagoon-internal-registry-secret
+          priorityClassName: lagoon-priority-production
+          restartPolicy: Never
+          securityContext:
+            fsGroup: 10001
+            runAsGroup: 0
+            runAsUser: 10000
+          volumes:
+          - name: lagoon-sshkey
+            secret:
+              defaultMode: 420
+              secretName: lagoon-sshkey
+          - emptyDir: {}
+            name: nginx-php-twig
+          - name: nginx-php
+            persistentVolumeClaim:
+              claimName: nginx-php
+  schedule: 18,48 * * * *
+  startingDeadlineSeconds: 240
+  successfulJobsHistoryLimit: 0
+status: {}

--- a/internal/testdata/complex/service-templates/service5/deployment-cli.yaml
+++ b/internal/testdata/complex/service-templates/service5/deployment-cli.yaml
@@ -1,0 +1,103 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: cli
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: cli-persistent
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: cli
+    lagoon.sh/service-type: cli-persistent
+    lagoon.sh/template: cli-persistent-0.1.0
+  name: cli
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: cli
+      app.kubernetes.io/name: cli-persistent
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        lagoon.sh/branch: main
+        lagoon.sh/configMapSha: abcdefg1234567890
+        lagoon.sh/version: v2.7.x
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: cli
+        app.kubernetes.io/managed-by: build-deploy-tool
+        app.kubernetes.io/name: cli-persistent
+        lagoon.sh/buildType: branch
+        lagoon.sh/environment: main
+        lagoon.sh/environmentType: production
+        lagoon.sh/project: example-project
+        lagoon.sh/service: cli
+        lagoon.sh/service-type: cli-persistent
+        lagoon.sh/template: cli-persistent-0.1.0
+    spec:
+      containers:
+      - env:
+        - name: LAGOON_GIT_SHA
+          value: "0000000000000000000000000000000000000000"
+        - name: CRONJOBS
+          value: |
+            3,18,33,48 * * * * drush cron
+        - name: SERVICE_NAME
+          value: cli
+        envFrom:
+        - configMapRef:
+            name: lagoon-env
+        image: harbor.example/example-project/main/cli@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8
+        imagePullPolicy: Always
+        name: cli
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - if [ -x /bin/entrypoint-readiness ]; then /bin/entrypoint-readiness;
+              fi
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 2
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext: {}
+        volumeMounts:
+        - mountPath: /var/run/secrets/lagoon/sshkey/
+          name: lagoon-sshkey
+          readOnly: true
+        - mountPath: /app/docroot/sites/default/files//php
+          name: nginx-php-twig
+        - mountPath: /app/docroot/sites/default/files/
+          name: nginx-php
+      enableServiceLinks: false
+      imagePullSecrets:
+      - name: lagoon-internal-registry-secret
+      priorityClassName: lagoon-priority-production
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 0
+        runAsUser: 10000
+      volumes:
+      - name: lagoon-sshkey
+        secret:
+          defaultMode: 420
+          secretName: lagoon-sshkey
+      - emptyDir: {}
+        name: nginx-php-twig
+      - name: nginx-php
+        persistentVolumeClaim:
+          claimName: nginx-php
+status: {}

--- a/internal/testdata/complex/service-templates/service5/deployment-nginx-php.yaml
+++ b/internal/testdata/complex/service-templates/service5/deployment-nginx-php.yaml
@@ -1,0 +1,155 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: nginx-php
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: nginx-php-persistent
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: nginx-php
+    lagoon.sh/service-type: nginx-php-persistent
+    lagoon.sh/template: nginx-php-persistent-0.1.0
+  name: nginx-php
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: nginx-php
+      app.kubernetes.io/name: nginx-php-persistent
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        lagoon.sh/branch: main
+        lagoon.sh/configMapSha: abcdefg1234567890
+        lagoon.sh/version: v2.7.x
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: nginx-php
+        app.kubernetes.io/managed-by: build-deploy-tool
+        app.kubernetes.io/name: nginx-php-persistent
+        lagoon.sh/buildType: branch
+        lagoon.sh/environment: main
+        lagoon.sh/environmentType: production
+        lagoon.sh/project: example-project
+        lagoon.sh/service: nginx-php
+        lagoon.sh/service-type: nginx-php-persistent
+        lagoon.sh/template: nginx-php-persistent-0.1.0
+    spec:
+      containers:
+      - env:
+        - name: NGINX_FASTCGI_PASS
+          value: 127.0.0.1
+        - name: LAGOON_GIT_SHA
+          value: "0000000000000000000000000000000000000000"
+        - name: CRONJOBS
+        - name: SERVICE_NAME
+          value: nginx-php
+        envFrom:
+        - configMapRef:
+            name: lagoon-env
+        image: harbor.example/example-project/main/nginx@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8
+        imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /nginx_status
+            port: 50000
+          initialDelaySeconds: 900
+          timeoutSeconds: 3
+        name: nginx
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /nginx_status
+            port: 50000
+          initialDelaySeconds: 1
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext: {}
+        volumeMounts:
+        - mountPath: /app/docroot/sites/default/files/
+          name: nginx-php
+      - env:
+        - name: NGINX_FASTCGI_PASS
+          value: 127.0.0.1
+        - name: LAGOON_GIT_SHA
+          value: "0000000000000000000000000000000000000000"
+        - name: SERVICE_NAME
+          value: nginx-php
+        envFrom:
+        - configMapRef:
+            name: lagoon-env
+        image: harbor.example/example-project/main/php@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8
+        imagePullPolicy: Always
+        livenessProbe:
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          tcpSocket:
+            port: 9000
+        name: php
+        ports:
+        - containerPort: 9000
+          name: http
+          protocol: TCP
+        readinessProbe:
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          tcpSocket:
+            port: 9000
+        resources:
+          requests:
+            cpu: 10m
+            memory: 100Mi
+        securityContext: {}
+        volumeMounts:
+        - mountPath: /app/docroot/sites/default/files/
+          name: nginx-php
+        - mountPath: /app/docroot/sites/default/files//php
+          name: nginx-php-twig
+      enableServiceLinks: false
+      imagePullSecrets:
+      - name: lagoon-internal-registry-secret
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - "set -e\nSENTINEL=\"/storage/.lagoon-rootless-migration-complete\"\nif !
+          [ -f \"$SENTINEL\" ]; then\n\tfind /storage -exec chown 10000:0 {} +\n\tfind
+          /storage -exec chmod a+r,u+w {} +\n\tfind /storage -type d -exec chmod a+x
+          {} +\n\ttouch \"$SENTINEL\"\nfi"
+        image: library/busybox:musl
+        imagePullPolicy: IfNotPresent
+        name: fix-storage-permissions
+        resources: {}
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /storage
+          name: nginx-php
+      priorityClassName: lagoon-priority-production
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 0
+        runAsUser: 10000
+      volumes:
+      - name: nginx-php
+        persistentVolumeClaim:
+          claimName: nginx-php
+      - emptyDir: {}
+        name: nginx-php-twig
+status: {}

--- a/internal/testdata/complex/service-templates/service5/deployment-redis.yaml
+++ b/internal/testdata/complex/service-templates/service5/deployment-redis.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: redis
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: redis
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: redis
+    lagoon.sh/service-type: redis
+    lagoon.sh/template: redis-0.1.0
+  name: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: redis
+      app.kubernetes.io/name: redis
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        lagoon.sh/branch: main
+        lagoon.sh/configMapSha: abcdefg1234567890
+        lagoon.sh/version: v2.7.x
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: redis
+        app.kubernetes.io/managed-by: build-deploy-tool
+        app.kubernetes.io/name: redis
+        lagoon.sh/buildType: branch
+        lagoon.sh/environment: main
+        lagoon.sh/environmentType: production
+        lagoon.sh/project: example-project
+        lagoon.sh/service: redis
+        lagoon.sh/service-type: redis
+        lagoon.sh/template: redis-0.1.0
+    spec:
+      containers:
+      - env:
+        - name: LAGOON_GIT_SHA
+          value: "0000000000000000000000000000000000000000"
+        - name: CRONJOBS
+        - name: SERVICE_NAME
+          value: redis
+        envFrom:
+        - configMapRef:
+            name: lagoon-env
+        image: harbor.example/example-project/main/redis@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8
+        imagePullPolicy: Always
+        livenessProbe:
+          initialDelaySeconds: 120
+          tcpSocket:
+            port: 6379
+          timeoutSeconds: 1
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: 6379-tcp
+          protocol: TCP
+        readinessProbe:
+          initialDelaySeconds: 1
+          tcpSocket:
+            port: 6379
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext: {}
+      enableServiceLinks: false
+      imagePullSecrets:
+      - name: lagoon-internal-registry-secret
+      priorityClassName: lagoon-priority-production
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 0
+        runAsUser: 10000
+status: {}

--- a/internal/testdata/complex/service-templates/service5/deployment-varnish.yaml
+++ b/internal/testdata/complex/service-templates/service5/deployment-varnish.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: varnish
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: varnish
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: varnish
+    lagoon.sh/service-type: varnish
+    lagoon.sh/template: varnish-0.1.0
+  name: varnish
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: varnish
+      app.kubernetes.io/name: varnish
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        lagoon.sh/branch: main
+        lagoon.sh/configMapSha: abcdefg1234567890
+        lagoon.sh/version: v2.7.x
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: varnish
+        app.kubernetes.io/managed-by: build-deploy-tool
+        app.kubernetes.io/name: varnish
+        lagoon.sh/buildType: branch
+        lagoon.sh/environment: main
+        lagoon.sh/environmentType: production
+        lagoon.sh/project: example-project
+        lagoon.sh/service: varnish
+        lagoon.sh/service-type: varnish
+        lagoon.sh/template: varnish-0.1.0
+    spec:
+      containers:
+      - env:
+        - name: LAGOON_GIT_SHA
+          value: "0000000000000000000000000000000000000000"
+        - name: CRONJOBS
+        - name: SERVICE_NAME
+          value: varnish
+        envFrom:
+        - configMapRef:
+            name: lagoon-env
+        image: harbor.example/example-project/main/varnish@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8
+        imagePullPolicy: Always
+        livenessProbe:
+          initialDelaySeconds: 60
+          tcpSocket:
+            port: 8080
+          timeoutSeconds: 10
+        name: varnish
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        - containerPort: 6082
+          name: controlport
+          protocol: TCP
+        readinessProbe:
+          initialDelaySeconds: 1
+          tcpSocket:
+            port: 8080
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext: {}
+      enableServiceLinks: false
+      imagePullSecrets:
+      - name: lagoon-internal-registry-secret
+      priorityClassName: lagoon-priority-production
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 0
+        runAsUser: 10000
+status: {}

--- a/internal/testdata/complex/service-templates/service5/pvc-nginx-php.yaml
+++ b/internal/testdata/complex/service-templates/service5/pvc-nginx-php.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    k8up.io/backup: "true"
+    k8up.syn.tools/backup: "true"
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: nginx-php
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: nginx-php-persistent
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: nginx-php
+    lagoon.sh/service-type: nginx-php-persistent
+    lagoon.sh/template: nginx-php-persistent-0.1.0
+  name: nginx-php
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: bulk
+status: {}

--- a/internal/testdata/complex/service-templates/service5/service-nginx-php.yaml
+++ b/internal/testdata/complex/service-templates/service5/service-nginx-php.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: nginx-php
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: nginx-php-persistent
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: nginx-php
+    lagoon.sh/service-type: nginx-php-persistent
+    lagoon.sh/template: nginx-php-persistent-0.1.0
+  name: nginx-php
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: http
+  selector:
+    app.kubernetes.io/instance: nginx-php
+    app.kubernetes.io/name: nginx-php-persistent
+status:
+  loadBalancer: {}

--- a/internal/testdata/complex/service-templates/service5/service-redis.yaml
+++ b/internal/testdata/complex/service-templates/service5/service-redis.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: redis
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: redis
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: redis
+    lagoon.sh/service-type: redis
+    lagoon.sh/template: redis-0.1.0
+  name: redis
+spec:
+  ports:
+  - name: 6379-tcp
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app.kubernetes.io/instance: redis
+    app.kubernetes.io/name: redis
+status:
+  loadBalancer: {}

--- a/internal/testdata/complex/service-templates/service5/service-varnish.yaml
+++ b/internal/testdata/complex/service-templates/service5/service-varnish.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: varnish
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: varnish
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: varnish
+    lagoon.sh/service-type: varnish
+    lagoon.sh/template: varnish-0.1.0
+  name: varnish
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: http
+  - name: controlport
+    port: 6082
+    protocol: TCP
+    targetPort: controlport
+  selector:
+    app.kubernetes.io/instance: varnish
+    app.kubernetes.io/name: varnish
+status:
+  loadBalancer: {}

--- a/internal/testdata/testdata.go
+++ b/internal/testdata/testdata.go
@@ -58,6 +58,7 @@ type TestData struct {
 	DynamicSecrets             []string
 	DynamicDBaaSSecrets        []string
 	ImageCacheBuildArgsJSON    string
+	SSHPrivateKey              string
 }
 
 // helper function to set up all the environment variables from provided testdata
@@ -192,6 +193,10 @@ func SetupEnvironment(rootCmd cobra.Command, templatePath string, t TestData) (g
 	if err != nil {
 		return generator.GeneratorInput{}, err
 	}
+	err = os.Setenv("SSH_PRIVATE_KEY", t.SSHPrivateKey)
+	if err != nil {
+		return generator.GeneratorInput{}, err
+	}
 
 	generator, err := generator.GenerateInput(rootCmd, false)
 	if err != nil {
@@ -238,6 +243,7 @@ func GetSeedData(t TestData, defaultProjectVariables bool) TestData {
 		SourceRepository: "ssh://git@example.com/lagoon-demo.git",
 		Kubernetes:       "remote-cluster1",
 		GitSHA:           "abcdefg123456",
+		SSHPrivateKey:    "-----BEGIN OPENSSH PRIVATE KEY-----\nthisisafakekey\n-----END OPENSSH PRIVATE KEY-----",
 	}
 	if t.ProjectName != "" {
 		rt.ProjectName = t.ProjectName
@@ -334,6 +340,9 @@ func GetSeedData(t TestData, defaultProjectVariables bool) TestData {
 	}
 	if t.ImageCacheBuildArgsJSON != "" {
 		rt.ImageCacheBuildArgsJSON = t.ImageCacheBuildArgsJSON
+	}
+	if t.SSHPrivateKey != "" {
+		rt.SSHPrivateKey = t.SSHPrivateKey
 	}
 	return rt
 }


### PR DESCRIPTION
fixes an incorrect assumption that all dockerhub images would be from public repositories. Now includes a wrapper that will remove the imagecache injection on dockerhub images if a private repository has been logged into.

pull rate limits will be applied to that user instead of using an imagecache (if an imagecache was supplied)

Also adds a missing build arg for `LAGOON_SSH_PRIVATE_KEY`

Additionally, fixes up a missing or incorrectly associated podsecuritycontext to some services that previously only used `fsGroup: 0`

closes #347 