### PR TITLE
feat: override to be able to force cronjob into service pod

### DIFF
--- a/cmd/template_lagoonservices_test.go
+++ b/cmd/template_lagoonservices_test.go
@@ -350,6 +350,21 @@ func TestTemplateLagoonServices(t *testing.T) {
 			templatePath: "testoutput",
 			want:         "internal/testdata/complex/service-templates/service4",
 		},
+		{
+			name: "test10 basic deployment native cronjobs disabled",
+			args: testdata.GetSeedData(
+				testdata.TestData{
+					ProjectName:     "example-project",
+					EnvironmentName: "main",
+					Branch:          "main",
+					LagoonYAML:      "internal/testdata/basic/lagoon-cronjob-native-disable.yml",
+					ImageReferences: map[string]string{
+						"node": "harbor.example/example-project/main/node@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8",
+					},
+				}, true),
+			templatePath: "testoutput",
+			want:         "internal/testdata/basic/service-templates/service8",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/generator/services.go
+++ b/internal/generator/services.go
@@ -420,7 +420,8 @@ func composeToServiceValues(
 					if err != nil {
 						return ServiceValues{}, fmt.Errorf("unable to convert crontab for cronjob %s: %v", cronjob.Name, err)
 					}
-					if inpod {
+					// if the cronjob is inpod, or the cronjob has an inpod flag override
+					if inpod || (cronjob.InPod != nil && *cronjob.InPod) {
 						inpodcronjobs = append(inpodcronjobs, cronjob)
 					} else {
 						// make the cronjob name kubernetes compliant

--- a/internal/lagoon/lagoon.go
+++ b/internal/lagoon/lagoon.go
@@ -33,6 +33,7 @@ type Cronjob struct {
 	Service  string `json:"service"`
 	Schedule string `json:"schedule"`
 	Command  string `json:"command"`
+	InPod    *bool  `json:"inPod"`
 }
 
 type Override struct {

--- a/internal/lagoon/lagoon_test.go
+++ b/internal/lagoon/lagoon_test.go
@@ -441,6 +441,38 @@ func TestUnmarshalLagoonYAML(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "test-cronjobs-inpod-only",
+			args: args{
+				file: "test-resources/lagoon-yaml/test10/lagoon.yml",
+				l:    &YAML{},
+			},
+			want: &YAML{
+				DockerComposeYAML: "docker-compose.yml",
+				Environments: Environments{
+					"main": Environment{
+						Routes: []map[string][]Route{
+							{
+								"nginx": {
+									{
+										Name: "a.example.com",
+									},
+								},
+							},
+						},
+						Cronjobs: []Cronjob{
+							{
+								Name:     "drush cron",
+								Command:  "drush cron",
+								Service:  "cli",
+								Schedule: "*/30 * * * *",
+								InPod:    helpers.BoolPtr(true),
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/lagoon/test-resources/lagoon-yaml/test10/lagoon.yml
+++ b/internal/lagoon/test-resources/lagoon-yaml/test10/lagoon.yml
@@ -1,0 +1,16 @@
+---
+docker-compose-yaml: docker-compose.yml
+
+project: content-example-com
+
+environments:
+  main:
+    cronjobs:
+      - name: drush cron
+        schedule: "*/30 * * * *"
+        command: 'drush cron'
+        service: cli
+        inPod: true
+    routes:
+    -   nginx:
+        - a.example.com

--- a/internal/testdata/basic/lagoon-cronjob-native-disable.yml
+++ b/internal/testdata/basic/lagoon-cronjob-native-disable.yml
@@ -1,0 +1,21 @@
+docker-compose-yaml: internal/testdata/basic/docker-compose.yml
+
+environment_variables:
+  git_sha: "true"
+
+environments:
+  main:
+    routes:
+      - node:
+          - example.com
+    cronjobs:
+      - name: drush cron
+        schedule: "*/15 * * * *"
+        command: drush cron
+        service: node
+        inPod: true # not required as the interval is suited to in pod already
+      - name: drush cron2
+        schedule: "*/30 * * * *"
+        command: drush cron
+        service: node
+        inPod: true

--- a/internal/testdata/basic/service-templates/service8/deployment-node.yaml
+++ b/internal/testdata/basic/service-templates/service8/deployment-node.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: node
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: basic
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: node
+    lagoon.sh/service-type: basic
+    lagoon.sh/template: basic-0.1.0
+  name: node
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: node
+      app.kubernetes.io/name: basic
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        lagoon.sh/branch: main
+        lagoon.sh/configMapSha: abcdefg1234567890
+        lagoon.sh/version: v2.7.x
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: node
+        app.kubernetes.io/managed-by: build-deploy-tool
+        app.kubernetes.io/name: basic
+        lagoon.sh/buildType: branch
+        lagoon.sh/environment: main
+        lagoon.sh/environmentType: production
+        lagoon.sh/project: example-project
+        lagoon.sh/service: node
+        lagoon.sh/service-type: basic
+        lagoon.sh/template: basic-0.1.0
+    spec:
+      containers:
+      - env:
+        - name: LAGOON_GIT_SHA
+          value: abcdefg123456
+        - name: CRONJOBS
+          value: |
+            3,18,33,48 * * * * drush cron
+            18,48 * * * * drush cron
+        - name: SERVICE_NAME
+          value: node
+        envFrom:
+        - configMapRef:
+            name: lagoon-env
+        image: harbor.example/example-project/main/node@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8
+        imagePullPolicy: Always
+        livenessProbe:
+          initialDelaySeconds: 60
+          tcpSocket:
+            port: 1234
+          timeoutSeconds: 10
+        name: basic
+        ports:
+        - containerPort: 1234
+          name: tcp-1234
+          protocol: TCP
+        - containerPort: 8191
+          name: tcp-8191
+          protocol: TCP
+        - containerPort: 9001
+          name: udp-9001
+          protocol: UDP
+        readinessProbe:
+          initialDelaySeconds: 1
+          tcpSocket:
+            port: 1234
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext: {}
+      enableServiceLinks: false
+      imagePullSecrets:
+      - name: lagoon-internal-registry-secret
+      priorityClassName: lagoon-priority-production
+status: {}

--- a/internal/testdata/basic/service-templates/service8/service-node.yaml
+++ b/internal/testdata/basic/service-templates/service8/service-node.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: node
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: basic
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: node
+    lagoon.sh/service-type: basic
+    lagoon.sh/template: basic-0.1.0
+  name: node
+spec:
+  ports:
+  - name: tcp-1234
+    port: 1234
+    protocol: TCP
+    targetPort: tcp-1234
+  - name: tcp-8191
+    port: 8191
+    protocol: TCP
+    targetPort: tcp-8191
+  - name: udp-9001
+    port: 9001
+    protocol: UDP
+    targetPort: udp-9001
+  selector:
+    app.kubernetes.io/instance: node
+    app.kubernetes.io/name: basic
+status:
+  loadBalancer: {}


### PR DESCRIPTION
In some cases, a cronjob that would typically be run as a native kuberentes `CronJob` type may be better to run within the pod of the service directly. Since the in pod and native kubernetes switch is based on the interval of the cronjob, there is no way to do this without increasing the frequency of the cronjob, or writing a wrapper around the cronjob.

This offers a simple way to tell a cronjob to run in the service pod instead of a kubernetes native `CronJob` by way of an `inPod` field.

Set this to `true`, and the pod will be converted to an in pod cronjob:
```
- name: my special cronjob
  schedule: "45 * * * *"
  command: example cronjob command
  service: cli
  inPod: true
```