### PR TITLE
fix: elasticsearch is actually elasticsearch-persistent

### DIFF
--- a/internal/servicetypes/elasticsearch.go
+++ b/internal/servicetypes/elasticsearch.go
@@ -13,7 +13,7 @@ import (
 var defaultElasticsearchPort int32 = 9200
 
 var elasticsearch = ServiceType{
-	Name: "elasticsearch",
+	Name: "elasticsearch-persistent",
 	Ports: ServicePorts{
 		Ports: []corev1.ServicePort{
 			{

--- a/internal/templating/services/test-resources/deployment/result-elasticsearch-1.yaml
+++ b/internal/templating/services/test-resources/deployment/result-elasticsearch-1.yaml
@@ -9,21 +9,21 @@ metadata:
   labels:
     app.kubernetes.io/instance: myservice
     app.kubernetes.io/managed-by: build-deploy-tool
-    app.kubernetes.io/name: elasticsearch
+    app.kubernetes.io/name: elasticsearch-persistent
     lagoon.sh/buildType: branch
     lagoon.sh/environment: environment-name
     lagoon.sh/environmentType: production
     lagoon.sh/project: example-project
     lagoon.sh/service: myservice
-    lagoon.sh/service-type: elasticsearch
-    lagoon.sh/template: elasticsearch-0.1.0
+    lagoon.sh/service-type: elasticsearch-persistent
+    lagoon.sh/template: elasticsearch-persistent-0.1.0
   name: myservice
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: myservice
-      app.kubernetes.io/name: elasticsearch
+      app.kubernetes.io/name: elasticsearch-persistent
   strategy:
     type: Recreate
   template:
@@ -39,14 +39,14 @@ spec:
       labels:
         app.kubernetes.io/instance: myservice
         app.kubernetes.io/managed-by: build-deploy-tool
-        app.kubernetes.io/name: elasticsearch
+        app.kubernetes.io/name: elasticsearch-persistent
         lagoon.sh/buildType: branch
         lagoon.sh/environment: environment-name
         lagoon.sh/environmentType: production
         lagoon.sh/project: example-project
         lagoon.sh/service: myservice
-        lagoon.sh/service-type: elasticsearch
-        lagoon.sh/template: elasticsearch-0.1.0
+        lagoon.sh/service-type: elasticsearch-persistent
+        lagoon.sh/template: elasticsearch-persistent-0.1.0
     spec:
       containers:
       - env:
@@ -124,21 +124,21 @@ metadata:
   labels:
     app.kubernetes.io/instance: myservice-size
     app.kubernetes.io/managed-by: build-deploy-tool
-    app.kubernetes.io/name: elasticsearch
+    app.kubernetes.io/name: elasticsearch-persistent
     lagoon.sh/buildType: branch
     lagoon.sh/environment: environment-name
     lagoon.sh/environmentType: production
     lagoon.sh/project: example-project
     lagoon.sh/service: myservice-size
-    lagoon.sh/service-type: elasticsearch
-    lagoon.sh/template: elasticsearch-0.1.0
+    lagoon.sh/service-type: elasticsearch-persistent
+    lagoon.sh/template: elasticsearch-persistent-0.1.0
   name: myservice-size
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: myservice-size
-      app.kubernetes.io/name: elasticsearch
+      app.kubernetes.io/name: elasticsearch-persistent
   strategy:
     type: Recreate
   template:
@@ -154,14 +154,14 @@ spec:
       labels:
         app.kubernetes.io/instance: myservice-size
         app.kubernetes.io/managed-by: build-deploy-tool
-        app.kubernetes.io/name: elasticsearch
+        app.kubernetes.io/name: elasticsearch-persistent
         lagoon.sh/buildType: branch
         lagoon.sh/environment: environment-name
         lagoon.sh/environmentType: production
         lagoon.sh/project: example-project
         lagoon.sh/service: myservice-size
-        lagoon.sh/service-type: elasticsearch
-        lagoon.sh/template: elasticsearch-0.1.0
+        lagoon.sh/service-type: elasticsearch-persistent
+        lagoon.sh/template: elasticsearch-persistent-0.1.0
     spec:
       containers:
       - env:

--- a/internal/templating/services/test-resources/pvc/result-elasticsearch-1.yaml
+++ b/internal/templating/services/test-resources/pvc/result-elasticsearch-1.yaml
@@ -11,14 +11,14 @@ metadata:
   labels:
     app.kubernetes.io/instance: myservice
     app.kubernetes.io/managed-by: build-deploy-tool
-    app.kubernetes.io/name: elasticsearch
+    app.kubernetes.io/name: elasticsearch-persistent
     lagoon.sh/buildType: branch
     lagoon.sh/environment: environment-name
     lagoon.sh/environmentType: production
     lagoon.sh/project: example-project
     lagoon.sh/service: myservice
-    lagoon.sh/service-type: elasticsearch
-    lagoon.sh/template: elasticsearch-0.1.0
+    lagoon.sh/service-type: elasticsearch-persistent
+    lagoon.sh/template: elasticsearch-persistent-0.1.0
   name: myservice
 spec:
   accessModes:
@@ -40,14 +40,14 @@ metadata:
   labels:
     app.kubernetes.io/instance: myservice-size
     app.kubernetes.io/managed-by: build-deploy-tool
-    app.kubernetes.io/name: elasticsearch
+    app.kubernetes.io/name: elasticsearch-persistent
     lagoon.sh/buildType: branch
     lagoon.sh/environment: environment-name
     lagoon.sh/environmentType: production
     lagoon.sh/project: example-project
     lagoon.sh/service: myservice-size
-    lagoon.sh/service-type: elasticsearch
-    lagoon.sh/template: elasticsearch-0.1.0
+    lagoon.sh/service-type: elasticsearch-persistent
+    lagoon.sh/template: elasticsearch-persistent-0.1.0
   name: myservice-size
 spec:
   accessModes:

--- a/internal/templating/services/test-resources/service/result-elasticsearch-1.yaml
+++ b/internal/templating/services/test-resources/service/result-elasticsearch-1.yaml
@@ -9,14 +9,14 @@ metadata:
   labels:
     app.kubernetes.io/instance: myservice
     app.kubernetes.io/managed-by: build-deploy-tool
-    app.kubernetes.io/name: elasticsearch
+    app.kubernetes.io/name: elasticsearch-persistent
     lagoon.sh/buildType: branch
     lagoon.sh/environment: environment-name
     lagoon.sh/environmentType: production
     lagoon.sh/project: example-project
     lagoon.sh/service: myservice
-    lagoon.sh/service-type: elasticsearch
-    lagoon.sh/template: elasticsearch-0.1.0
+    lagoon.sh/service-type: elasticsearch-persistent
+    lagoon.sh/template: elasticsearch-persistent-0.1.0
   name: myservice
 spec:
   ports:
@@ -26,7 +26,7 @@ spec:
     targetPort: 9200
   selector:
     app.kubernetes.io/instance: myservice
-    app.kubernetes.io/name: elasticsearch
+    app.kubernetes.io/name: elasticsearch-persistent
 status:
   loadBalancer: {}
 ---
@@ -40,14 +40,14 @@ metadata:
   labels:
     app.kubernetes.io/instance: myservice-size
     app.kubernetes.io/managed-by: build-deploy-tool
-    app.kubernetes.io/name: elasticsearch
+    app.kubernetes.io/name: elasticsearch-persistent
     lagoon.sh/buildType: branch
     lagoon.sh/environment: environment-name
     lagoon.sh/environmentType: production
     lagoon.sh/project: example-project
     lagoon.sh/service: myservice-size
-    lagoon.sh/service-type: elasticsearch
-    lagoon.sh/template: elasticsearch-0.1.0
+    lagoon.sh/service-type: elasticsearch-persistent
+    lagoon.sh/template: elasticsearch-persistent-0.1.0
   name: myservice-size
 spec:
   ports:
@@ -57,6 +57,6 @@ spec:
     targetPort: 9200
   selector:
     app.kubernetes.io/instance: myservice-size
-    app.kubernetes.io/name: elasticsearch
+    app.kubernetes.io/name: elasticsearch-persistent
 status:
   loadBalancer: {}


### PR DESCRIPTION
Fixes an issue with the template being `elasticsearch-persistent` instead of just `elasticsearch`