### PR TITLE
fix: change duplicate port name in nginx service type

### DIFF
--- a/internal/servicetypes/nginx.go
+++ b/internal/servicetypes/nginx.go
@@ -137,7 +137,7 @@ var nginxPHP = ServiceType{
 			SecurityContext: &corev1.SecurityContext{},
 			Ports: []corev1.ContainerPort{
 				{
-					Name:          "http",
+					Name:          "php",
 					ContainerPort: defaultPHPPort,
 					Protocol:      corev1.ProtocolTCP,
 				},


### PR DESCRIPTION
The nginx service type contains a duplicate port name http which is used by container nginx port 8080 and container php port 9000. This causes a race condition.

The nginx service targets port name nginx, which in some cases may end up good pointing to nginx, but in some other cases this might fail since requests are forwarded directly to the php container.

Before the Go rewrite for Kubernetes templating, port 9000 of the php container was not named