### PR TITLE
fix: Use distinct container port names

### DIFF
--- a/internal/servicetypes/nginx.go
+++ b/internal/servicetypes/nginx.go
@@ -137,7 +137,7 @@ var nginxPHP = ServiceType{
 			SecurityContext: &corev1.SecurityContext{},
 			Ports: []corev1.ContainerPort{
 				{
-					Name:          "http",
+					Name:          "php",
 					ContainerPort: defaultPHPPort,
 					Protocol:      corev1.ProtocolTCP,
 				},

--- a/internal/templating/services/test-resources/deployment/result-nginx-1.yaml
+++ b/internal/templating/services/test-resources/deployment/result-nginx-1.yaml
@@ -101,7 +101,7 @@ spec:
         name: php
         ports:
         - containerPort: 9000
-          name: http
+          name: php
           protocol: TCP
         readinessProbe:
           initialDelaySeconds: 2
@@ -228,7 +228,7 @@ spec:
         name: php
         ports:
         - containerPort: 9000
-          name: http
+          name: php
           protocol: TCP
         readinessProbe:
           initialDelaySeconds: 2

--- a/internal/templating/services/test-resources/deployment/result-nginx-2.yaml
+++ b/internal/templating/services/test-resources/deployment/result-nginx-2.yaml
@@ -101,7 +101,7 @@ spec:
         name: php
         ports:
         - containerPort: 9000
-          name: http
+          name: php
           protocol: TCP
         readinessProbe:
           initialDelaySeconds: 2
@@ -229,7 +229,7 @@ spec:
         name: php
         ports:
         - containerPort: 9000
-          name: http
+          name: php
           protocol: TCP
         readinessProbe:
           initialDelaySeconds: 2

--- a/internal/testdata/complex/service-templates/service1/deployment-nginx-php.yaml
+++ b/internal/testdata/complex/service-templates/service1/deployment-nginx-php.yaml
@@ -104,7 +104,7 @@ spec:
         name: php
         ports:
         - containerPort: 9000
-          name: http
+          name: php
           protocol: TCP
         readinessProbe:
           initialDelaySeconds: 2

--- a/internal/testdata/complex/service-templates/service2/deployment-nginx-php.yaml
+++ b/internal/testdata/complex/service-templates/service2/deployment-nginx-php.yaml
@@ -104,7 +104,7 @@ spec:
         name: php
         ports:
         - containerPort: 9000
-          name: http
+          name: php
           protocol: TCP
         readinessProbe:
           initialDelaySeconds: 2

--- a/internal/testdata/complex/service-templates/service5/deployment-nginx-php.yaml
+++ b/internal/testdata/complex/service-templates/service5/deployment-nginx-php.yaml
@@ -104,7 +104,7 @@ spec:
         name: php
         ports:
         - containerPort: 9000
-          name: http
+          name: php
           protocol: TCP
         readinessProbe:
           initialDelaySeconds: 2

--- a/internal/testdata/complex/service-templates/service6/deployment-nginx-php.yaml
+++ b/internal/testdata/complex/service-templates/service6/deployment-nginx-php.yaml
@@ -114,7 +114,7 @@ spec:
         name: php
         ports:
         - containerPort: 9000
-          name: http
+          name: php
           protocol: TCP
         readinessProbe:
           initialDelaySeconds: 2


### PR DESCRIPTION
This introduces the port name "php" for the additional PHP container.

Using the same port name twice can lead to situations where a service
pointing to a named port would route the traffic to the wrong container.