### PR TITLE
fix: add labels back to cronjobs with a prefix

### DIFF
--- a/internal/templating/services/templates_cronjob.go
+++ b/internal/templating/services/templates_cronjob.go
@@ -34,17 +34,15 @@ func GenerateCronjobTemplate(
 				// add the default labels
 				labels := map[string]string{
 					"app.kubernetes.io/managed-by": "build-deploy-tool",
-					// @TODO: these are removed for now to resolve a deployment label matching issue
-					// that can crop up
-					// "app.kubernetes.io/name":       serviceTypeValues.Name,
-					// "app.kubernetes.io/instance":   serviceValues.OverrideName,
-					"lagoon.sh/project":         buildValues.Project,
-					"lagoon.sh/environment":     buildValues.Environment,
-					"lagoon.sh/environmentType": buildValues.EnvironmentType,
-					"lagoon.sh/buildType":       buildValues.BuildType,
-					"lagoon.sh/template":        fmt.Sprintf("%s-%s", serviceTypeValues.Name, "0.1.0"),
-					"lagoon.sh/service":         serviceValues.OverrideName,
-					"lagoon.sh/service-type":    serviceTypeValues.Name,
+					"app.kubernetes.io/name":       fmt.Sprintf("cronjob-%s", serviceTypeValues.Name),
+					"app.kubernetes.io/instance":   fmt.Sprintf("cronjob-%s", serviceValues.OverrideName),
+					"lagoon.sh/project":            buildValues.Project,
+					"lagoon.sh/environment":        buildValues.Environment,
+					"lagoon.sh/environmentType":    buildValues.EnvironmentType,
+					"lagoon.sh/buildType":          buildValues.BuildType,
+					"lagoon.sh/template":           fmt.Sprintf("%s-%s", serviceTypeValues.Name, "0.1.0"),
+					"lagoon.sh/service":            serviceValues.OverrideName,
+					"lagoon.sh/service-type":       serviceTypeValues.Name,
 				}
 
 				// add the default annotations
@@ -72,20 +70,6 @@ func GenerateCronjobTemplate(
 					serviceValues,
 					serviceTypeValues,
 				}
-
-				// cronjobs don't need backups
-				// if serviceTypeValues.Volumes.BackupConfiguration.Command != "" {
-				// 	bc := servicetypes.BackupConfiguration{}
-				// 	helpers.TemplateThings(tpld, serviceTypeValues.Volumes.BackupConfiguration, &bc)
-				// 	switch buildValues.Backup.K8upVersion {
-				// 	case "v2":
-				// 		templateAnnotations["k8up.io/backupcommand"] = bc.Command
-				// 		templateAnnotations["k8up.io/file-extension"] = bc.FileExtension
-				// 	default:
-				// 		templateAnnotations["k8up.syn.tools/backupcommand"] = bc.Command
-				// 		templateAnnotations["k8up.syn.tools/file-extension"] = bc.FileExtension
-				// 	}
-				// }
 
 				cronjob := &batchv1.CronJob{
 					TypeMeta: metav1.TypeMeta{

--- a/internal/templating/services/test-resources/cronjob/result-cli-1.yaml
+++ b/internal/templating/services/test-resources/cronjob/result-cli-1.yaml
@@ -7,7 +7,9 @@ metadata:
     lagoon.sh/version: v2.x.x
   creationTimestamp: null
   labels:
+    app.kubernetes.io/instance: cronjob-myservice
     app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: cronjob-cli
     lagoon.sh/buildType: branch
     lagoon.sh/environment: environment-name
     lagoon.sh/environmentType: production
@@ -31,7 +33,9 @@ spec:
             lagoon.sh/version: v2.x.x
           creationTimestamp: null
           labels:
+            app.kubernetes.io/instance: cronjob-myservice
             app.kubernetes.io/managed-by: build-deploy-tool
+            app.kubernetes.io/name: cronjob-cli
             lagoon.sh/buildType: branch
             lagoon.sh/environment: environment-name
             lagoon.sh/environmentType: production
@@ -93,7 +97,9 @@ metadata:
     lagoon.sh/version: v2.x.x
   creationTimestamp: null
   labels:
+    app.kubernetes.io/instance: cronjob-myservice
     app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: cronjob-cli
     lagoon.sh/buildType: branch
     lagoon.sh/environment: environment-name
     lagoon.sh/environmentType: production
@@ -117,7 +123,9 @@ spec:
             lagoon.sh/version: v2.x.x
           creationTimestamp: null
           labels:
+            app.kubernetes.io/instance: cronjob-myservice
             app.kubernetes.io/managed-by: build-deploy-tool
+            app.kubernetes.io/name: cronjob-cli
             lagoon.sh/buildType: branch
             lagoon.sh/environment: environment-name
             lagoon.sh/environmentType: production
@@ -179,7 +187,9 @@ metadata:
     lagoon.sh/version: v2.x.x
   creationTimestamp: null
   labels:
+    app.kubernetes.io/instance: cronjob-myservice-persist
     app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: cronjob-cli-persistent
     lagoon.sh/buildType: branch
     lagoon.sh/environment: environment-name
     lagoon.sh/environmentType: production
@@ -203,7 +213,9 @@ spec:
             lagoon.sh/version: v2.x.x
           creationTimestamp: null
           labels:
+            app.kubernetes.io/instance: cronjob-myservice-persist
             app.kubernetes.io/managed-by: build-deploy-tool
+            app.kubernetes.io/name: cronjob-cli-persistent
             lagoon.sh/buildType: branch
             lagoon.sh/environment: environment-name
             lagoon.sh/environmentType: production

--- a/internal/templating/services/test-resources/cronjob/result-cli-2.yaml
+++ b/internal/templating/services/test-resources/cronjob/result-cli-2.yaml
@@ -7,7 +7,9 @@ metadata:
     lagoon.sh/version: v2.x.x
   creationTimestamp: null
   labels:
+    app.kubernetes.io/instance: cronjob-myservice
     app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: cronjob-cli
     lagoon.sh/buildType: branch
     lagoon.sh/environment: environment-name
     lagoon.sh/environmentType: production
@@ -31,7 +33,9 @@ spec:
             lagoon.sh/version: v2.x.x
           creationTimestamp: null
           labels:
+            app.kubernetes.io/instance: cronjob-myservice
             app.kubernetes.io/managed-by: build-deploy-tool
+            app.kubernetes.io/name: cronjob-cli
             lagoon.sh/buildType: branch
             lagoon.sh/environment: environment-name
             lagoon.sh/environmentType: production
@@ -98,7 +102,9 @@ metadata:
     lagoon.sh/version: v2.x.x
   creationTimestamp: null
   labels:
+    app.kubernetes.io/instance: cronjob-myservice
     app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: cronjob-cli
     lagoon.sh/buildType: branch
     lagoon.sh/environment: environment-name
     lagoon.sh/environmentType: production
@@ -122,7 +128,9 @@ spec:
             lagoon.sh/version: v2.x.x
           creationTimestamp: null
           labels:
+            app.kubernetes.io/instance: cronjob-myservice
             app.kubernetes.io/managed-by: build-deploy-tool
+            app.kubernetes.io/name: cronjob-cli
             lagoon.sh/buildType: branch
             lagoon.sh/environment: environment-name
             lagoon.sh/environmentType: production
@@ -189,7 +197,9 @@ metadata:
     lagoon.sh/version: v2.x.x
   creationTimestamp: null
   labels:
+    app.kubernetes.io/instance: cronjob-myservice-persist
     app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: cronjob-cli-persistent
     lagoon.sh/buildType: branch
     lagoon.sh/environment: environment-name
     lagoon.sh/environmentType: production
@@ -213,7 +223,9 @@ spec:
             lagoon.sh/version: v2.x.x
           creationTimestamp: null
           labels:
+            app.kubernetes.io/instance: cronjob-myservice-persist
             app.kubernetes.io/managed-by: build-deploy-tool
+            app.kubernetes.io/name: cronjob-cli-persistent
             lagoon.sh/buildType: branch
             lagoon.sh/environment: environment-name
             lagoon.sh/environmentType: production

--- a/internal/testdata/complex/service-templates/service1/cronjob-cronjob-cli-drush-cron2.yaml
+++ b/internal/testdata/complex/service-templates/service1/cronjob-cronjob-cli-drush-cron2.yaml
@@ -7,7 +7,9 @@ metadata:
     lagoon.sh/version: v2.7.x
   creationTimestamp: null
   labels:
+    app.kubernetes.io/instance: cronjob-cli
     app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: cronjob-cli-persistent
     lagoon.sh/buildType: branch
     lagoon.sh/environment: main
     lagoon.sh/environmentType: production
@@ -31,7 +33,9 @@ spec:
             lagoon.sh/version: v2.7.x
           creationTimestamp: null
           labels:
+            app.kubernetes.io/instance: cronjob-cli
             app.kubernetes.io/managed-by: build-deploy-tool
+            app.kubernetes.io/name: cronjob-cli-persistent
             lagoon.sh/buildType: branch
             lagoon.sh/environment: main
             lagoon.sh/environmentType: production

--- a/internal/testdata/complex/service-templates/service2/cronjob-cronjob-cli-drush-cron2.yaml
+++ b/internal/testdata/complex/service-templates/service2/cronjob-cronjob-cli-drush-cron2.yaml
@@ -7,7 +7,9 @@ metadata:
     lagoon.sh/version: v2.7.x
   creationTimestamp: null
   labels:
+    app.kubernetes.io/instance: cronjob-cli
     app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: cronjob-cli-persistent
     lagoon.sh/buildType: branch
     lagoon.sh/environment: main
     lagoon.sh/environmentType: production
@@ -31,7 +33,9 @@ spec:
             lagoon.sh/version: v2.7.x
           creationTimestamp: null
           labels:
+            app.kubernetes.io/instance: cronjob-cli
             app.kubernetes.io/managed-by: build-deploy-tool
+            app.kubernetes.io/name: cronjob-cli-persistent
             lagoon.sh/buildType: branch
             lagoon.sh/environment: main
             lagoon.sh/environmentType: production

--- a/internal/testdata/complex/service-templates/service5/cronjob-cronjob-cli-drush-cron2.yaml
+++ b/internal/testdata/complex/service-templates/service5/cronjob-cronjob-cli-drush-cron2.yaml
@@ -7,7 +7,9 @@ metadata:
     lagoon.sh/version: v2.7.x
   creationTimestamp: null
   labels:
+    app.kubernetes.io/instance: cronjob-cli
     app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: cronjob-cli-persistent
     lagoon.sh/buildType: branch
     lagoon.sh/environment: main
     lagoon.sh/environmentType: production
@@ -31,7 +33,9 @@ spec:
             lagoon.sh/version: v2.7.x
           creationTimestamp: null
           labels:
+            app.kubernetes.io/instance: cronjob-cli
             app.kubernetes.io/managed-by: build-deploy-tool
+            app.kubernetes.io/name: cronjob-cli-persistent
             lagoon.sh/buildType: branch
             lagoon.sh/environment: main
             lagoon.sh/environmentType: production

--- a/internal/testdata/complex/service-templates/service6/cronjob-cronjob-cli-drush-cron2.yaml
+++ b/internal/testdata/complex/service-templates/service6/cronjob-cronjob-cli-drush-cron2.yaml
@@ -7,7 +7,9 @@ metadata:
     lagoon.sh/version: v2.7.x
   creationTimestamp: null
   labels:
+    app.kubernetes.io/instance: cronjob-cli
     app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: cronjob-cli-persistent
     lagoon.sh/buildType: branch
     lagoon.sh/environment: main
     lagoon.sh/environmentType: production
@@ -32,7 +34,9 @@ spec:
             lagoon.sh/version: v2.7.x
           creationTimestamp: null
           labels:
+            app.kubernetes.io/instance: cronjob-cli
             app.kubernetes.io/managed-by: build-deploy-tool
+            app.kubernetes.io/name: cronjob-cli-persistent
             lagoon.sh/buildType: branch
             lagoon.sh/environment: main
             lagoon.sh/environmentType: production


### PR DESCRIPTION
Due to the way builds apply templates, removing a label is not enough

In https://github.com/uselagoon/build-deploy-tool/commit/fb6924b5e389f9cbabde43f953675be95f0fad61 we removed the label from being set, but in old cronjobs this left the label in place. New cronjobs were not impacted though as they would never have the label.

This changes the behaviour to prefix the labels that would have been set with `cronjob-` so that the values are there, but are not the same as what a deployment would have to prevent them from being counted towards the deployment pods when being selected by SSH services