### PR TITLE
build: copy required go components to reduce cache invalidation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,12 @@ RUN go install github.com/a8m/envsubst/cmd/envsubst@v1.4.2
 
 WORKDIR /app
 
-COPY . ./
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+COPY main.go main.go
+COPY cmd/ cmd/
+COPY internal/ internal/
 
 ARG BUILD
 ARG GO_VER


### PR DESCRIPTION
Just changes up the `COPY . ./` in the dockerfile to copy in Go components only to try reduce cache invalidation