### PR TITLE
feat: variable replacement support for lagoon.base.image label

### DIFF
--- a/internal/generator/helpers_generator.go
+++ b/internal/generator/helpers_generator.go
@@ -301,8 +301,6 @@ func determineRefreshImage(serviceName, imageName string, labels map[string]stri
 			}
 		}
 
-		println(matches)
-
 		imageName = fmt.Sprintf("%v:%v", imageName, tagvalue)
 	}
 

--- a/internal/generator/helpers_generator_test.go
+++ b/internal/generator/helpers_generator_test.go
@@ -86,7 +86,6 @@ func Test_determineRefreshImage(t *testing.T) {
 	type args struct {
 		serviceName string
 		imageName   string
-		labels      map[string]string
 		envVars     []lagoon.EnvironmentVariable
 	}
 	tests := []struct {
@@ -100,34 +99,27 @@ func Test_determineRefreshImage(t *testing.T) {
 			args: args{
 				serviceName: "testservice",
 				imageName:   "image/name:latest",
-				labels:      nil,
 				envVars:     nil,
 			},
 			want:    "image/name:latest",
 			wantErr: false,
 		},
 		{
-			name: "Adds simple tag",
+			name: "Fails with no matching variable in envvars",
 			args: args{
 				serviceName: "testservice",
-				imageName:   "image/name",
-				labels: map[string]string{
-					"lagoon.base.image.tag": "sometag",
-				},
-				envVars: nil,
+				imageName:   "image/name:${NOENVVAR}",
+				envVars:     nil,
 			},
-			want:    "image/name:sometag",
-			wantErr: false,
+			want:    "",
+			wantErr: true,
 		},
 		{
-			name: "Fails with double tags",
+			name: "Fails with variable missing curly brackets",
 			args: args{
 				serviceName: "testservice",
-				imageName:   "image/name:latest",
-				labels: map[string]string{
-					"lagoon.base.image.tag": "sometag",
-				},
-				envVars: nil,
+				imageName:   "image/name:$NOENVVAR",
+				envVars:     nil,
 			},
 			want:    "",
 			wantErr: true,
@@ -136,11 +128,8 @@ func Test_determineRefreshImage(t *testing.T) {
 			name: "Tag with simple arg - fallback to default",
 			args: args{
 				serviceName: "testservice",
-				imageName:   "image/name",
-				labels: map[string]string{
-					"lagoon.base.image.tag": "$ENVVAR:-sometag",
-				},
-				envVars: nil,
+				imageName:   "image/name:${ENVVAR:-sometag}",
+				envVars:     nil,
 			},
 			want:    "image/name:sometag",
 			wantErr: false,
@@ -149,10 +138,7 @@ func Test_determineRefreshImage(t *testing.T) {
 			name: "Tag with env var that works",
 			args: args{
 				serviceName: "testservice",
-				imageName:   "image/name",
-				labels: map[string]string{
-					"lagoon.base.image.tag": "$ENVVAR:-sometag",
-				},
+				imageName:   "image/name:${ENVVAR:-sometag}",
 				envVars: []lagoon.EnvironmentVariable{
 					{
 						Name:  "ENVVAR",
@@ -166,12 +152,16 @@ func Test_determineRefreshImage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := determineRefreshImage(tt.args.serviceName, tt.args.imageName, tt.args.labels, tt.args.envVars)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("determineRefreshImage() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			got, errs := determineRefreshImage(tt.args.serviceName, tt.args.imageName, tt.args.envVars)
+			if len(errs) > 0 && !tt.wantErr {
+				for idx, err := range errs {
+					t.Errorf("determineRefreshImage() error = %v, wantErr %v", err, tt.wantErr)
+					if idx+1 == len(errs) {
+						return
+					}
+				}
 			}
-			if got != tt.want {
+			if got != tt.want && !tt.wantErr {
 				t.Errorf("determineRefreshImage() got = %v, want %v", got, tt.want)
 			}
 		})

--- a/internal/generator/helpers_generator_test.go
+++ b/internal/generator/helpers_generator_test.go
@@ -81,3 +81,99 @@ func Test_checkDuplicateCronjobs(t *testing.T) {
 		})
 	}
 }
+
+func Test_determineRefreshImage(t *testing.T) {
+	type args struct {
+		serviceName string
+		imageName   string
+		labels      map[string]string
+		envVars     []lagoon.EnvironmentVariable
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Identity function",
+			args: args{
+				serviceName: "testservice",
+				imageName:   "image/name:latest",
+				labels:      nil,
+				envVars:     nil,
+			},
+			want:    "image/name:latest",
+			wantErr: false,
+		},
+		{
+			name: "Adds simple tag",
+			args: args{
+				serviceName: "testservice",
+				imageName:   "image/name",
+				labels: map[string]string{
+					"lagoon.base.image.tag": "sometag",
+				},
+				envVars: nil,
+			},
+			want:    "image/name:sometag",
+			wantErr: false,
+		},
+		{
+			name: "Fails with double tags",
+			args: args{
+				serviceName: "testservice",
+				imageName:   "image/name:latest",
+				labels: map[string]string{
+					"lagoon.base.image.tag": "sometag",
+				},
+				envVars: nil,
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Tag with simple arg - fallback to default",
+			args: args{
+				serviceName: "testservice",
+				imageName:   "image/name",
+				labels: map[string]string{
+					"lagoon.base.image.tag": "$ENVVAR:-sometag",
+				},
+				envVars: nil,
+			},
+			want:    "image/name:sometag",
+			wantErr: false,
+		},
+		{
+			name: "Tag with env var that works",
+			args: args{
+				serviceName: "testservice",
+				imageName:   "image/name",
+				labels: map[string]string{
+					"lagoon.base.image.tag": "$ENVVAR:-sometag",
+				},
+				envVars: []lagoon.EnvironmentVariable{
+					{
+						Name:  "ENVVAR",
+						Value: "injectedTag",
+					},
+				},
+			},
+			want:    "image/name:injectedTag",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := determineRefreshImage(tt.args.serviceName, tt.args.imageName, tt.args.labels, tt.args.envVars)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("determineRefreshImage() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("determineRefreshImage() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/generator/services.go
+++ b/internal/generator/services.go
@@ -7,8 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/distribution/reference"
-
 	composetypes "github.com/compose-spec/compose-go/types"
 	"github.com/uselagoon/build-deploy-tool/internal/helpers"
 	"github.com/uselagoon/build-deploy-tool/internal/lagoon"
@@ -286,13 +284,17 @@ func composeToServiceValues(
 			}
 		}
 
+		// if any `lagoon.base.image` labels are set, we note them for docker pulling
+		// this allows us to refresh the docker-host's cache in cases where an image
+		// may have an update without a change in tag (i.e. "latest" tagged images)
 		baseimage := lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, "lagoon.base.image")
 		if baseimage != "" {
-			// First, let's ensure that the structure of the base image is valid
-			if !reference.ReferenceRegexp.MatchString(baseimage) {
-				return nil, fmt.Errorf("the 'lagoon.base.image' label defined on service %s in the docker-compose file is invalid ('%s') - please ensure it conforms to the structure `[REGISTRY_HOST[:REGISTRY_PORT]/]REPOSITORY[:TAG|@DIGEST]`", composeService, baseimage)
+
+			baseImageWithTag, err := determineRefreshImage(composeService, baseimage, composeServiceValues.Labels, buildValues.EnvironmentVariables)
+			if err != nil {
+				return nil, err
 			}
-			buildValues.ForcePullImages = append(buildValues.ForcePullImages, baseimage)
+			buildValues.ForcePullImages = append(buildValues.ForcePullImages, baseImageWithTag)
 		}
 
 		// if there are overrides defined in the lagoon API `LAGOON_SERVICE_TYPES`

--- a/internal/generator/services.go
+++ b/internal/generator/services.go
@@ -289,10 +289,15 @@ func composeToServiceValues(
 		// may have an update without a change in tag (i.e. "latest" tagged images)
 		baseimage := lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, "lagoon.base.image")
 		if baseimage != "" {
-
-			baseImageWithTag, err := determineRefreshImage(composeService, baseimage, composeServiceValues.Labels, buildValues.EnvironmentVariables)
-			if err != nil {
-				return nil, err
+			baseImageWithTag, errs := determineRefreshImage(composeService, baseimage, buildValues.EnvironmentVariables)
+			if len(errs) > 0 {
+				for idx, err := range errs {
+					if idx+1 == len(errs) {
+						return nil, err
+					} else {
+						fmt.Println(err)
+					}
+				}
 			}
 			buildValues.ForcePullImages = append(buildValues.ForcePullImages, baseImageWithTag)
 		}

--- a/internal/testdata/basic/docker-compose.forcebaseimagepull-2.yml
+++ b/internal/testdata/basic/docker-compose.forcebaseimagepull-2.yml
@@ -1,0 +1,23 @@
+version: '2'
+services:
+  node:
+    networks:
+      - amazeeio-network
+      - default
+    build:
+      context: internal/testdata/basic/docker
+      dockerfile: basic.dockerfile
+    labels:
+      lagoon.type: basic
+      lagoon.service.usecomposeports: true
+      lagoon.base.image: registry.com/${BASE_IMAGE_REPO:-namespace}/imagename:${BASE_IMAGE_TAG:-latest}
+    volumes:
+      - .:/app:delegated
+    ports:
+      - '1234'
+      - '8191'
+      - '9001/udp'
+
+networks:
+  amazeeio-network:
+    external: true

--- a/internal/testdata/basic/lagoon.forcebaseimagepull-2.yml
+++ b/internal/testdata/basic/lagoon.forcebaseimagepull-2.yml
@@ -1,0 +1,10 @@
+docker-compose-yaml: internal/testdata/basic/docker-compose.forcebaseimagepull-2.yml
+
+environment_variables:
+  git_sha: "true"
+
+environments:
+  main:
+    routes:
+      - node:
+          - example.com


### PR DESCRIPTION
This PR extends #355 by adding the ability to specify tags with environment variables.

It allows the `lagoon.base.image` task to be populated with variables that can be provided to a project or environment and parse them during a lagoon build stage to calculate the required base image to pull.

Variable replacement is similar to `envplate`. They must be in the `${}` format, ie
```
# no default, will error if `BASE_IMAGE_TAG` is not provided by the project or environment
lagoon.base.image: 'repo/image:${BASE_IMAGE_TAG}' 
# default of `main` if `BASE_IMAGE_TAG` is not provided by the project or environment
lagoon.base.image: 'repo/image:${BASE_IMAGE_TAG:-main}'`
# it is possible to replace more than just the tag too
lagoon.base.image: '${BASE_IMAGE_REPO:-repo}/image:${BASE_IMAGE_TAG:-main}'`
```

Nested variables like `${BASE_IMAGE_TAG:-${OTHER_IMAGE_TAG:-latest}}` will not work.