### PR TITLE
chore: add featureflag to change default buildkit setting

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -359,7 +359,12 @@ func NewGenerator(
 		bk, _ := strconv.ParseBool(dockerBuildKit.Value)
 		buildValues.DockerBuildKit = &bk
 	} else {
-		buildValues.DockerBuildKit = helpers.BoolPtr(true)
+		lffDockerbuildkit := CheckFeatureFlag("DOCKER_BUILDKIT", buildValues.EnvironmentVariables, false)
+		if lffDockerbuildkit == "disabled" {
+			buildValues.DockerBuildKit = helpers.BoolPtr(false)
+		} else {
+			buildValues.DockerBuildKit = helpers.BoolPtr(true)
+		}
 	}
 
 	// get any lagoon service type overrides


### PR DESCRIPTION
In #360 we changed buildkit to be enabled by default, this still leaves buildkit as enabled by default, but allows for the `LAGOON_FEATURE_FLAG_(DEFAULT|FORCE)_X` variable in the remote to change this default. If a user has added the existing `DOCKER_BUILDKIT` variable, this is still used.
