### PR TITLE
fix: default fastly watch status to true if not provided in variable

### DIFF
--- a/internal/lagoon/fastly.go
+++ b/internal/lagoon/fastly.go
@@ -28,12 +28,14 @@ func GenerateFastlyConfiguration(f *Fastly, noCacheServiceID, serviceID, route s
 	lfsID, err := GetLagoonVariable("LAGOON_FASTLY_SERVICE_ID", []string{"build", "global"}, variables)
 	if err == nil {
 		lfsIDSplit := strings.Split(lfsID.Value, ":")
-		if len(lfsIDSplit) == 1 {
-			return fmt.Errorf("no watch status was provided, only the service id")
-		}
-		watch, err := strconv.ParseBool(lfsIDSplit[1])
-		if err != nil {
-			return fmt.Errorf("the provided value %s is not a valid boolean", lfsIDSplit[1])
+		// default watch status to true
+		watch := true
+		if len(lfsIDSplit) > 1 {
+			// if the variable contains the watch status
+			watch, err = strconv.ParseBool(lfsIDSplit[1])
+			if err != nil {
+				return fmt.Errorf("variable LAGOON_FASTLY_SERVICE_ID provided watch value %s is not a valid boolean", lfsIDSplit[1])
+			}
 		}
 		f.ServiceID = lfsIDSplit[0]
 		f.Watch = watch
@@ -58,12 +60,14 @@ func GenerateFastlyConfiguration(f *Fastly, noCacheServiceID, serviceID, route s
 		for _, lfs := range lfsIDsSplit {
 			lfsIDSplit := strings.Split(lfs, ":")
 			if lfsIDSplit[0] == route {
-				if len(lfsIDSplit) == 2 {
-					return fmt.Errorf("no watch status was provided, only the route and service id")
-				}
-				watch, err := strconv.ParseBool(lfsIDSplit[2])
-				if err != nil {
-					return fmt.Errorf("the provided value %s is not a valid boolean", lfsIDSplit[2])
+				// default watch status to true
+				watch := true
+				if len(lfsIDSplit) > 2 {
+					// if the variable contains the watch status
+					watch, err = strconv.ParseBool(lfsIDSplit[2])
+					if err != nil {
+						return fmt.Errorf("variable LAGOON_FASTLY_SERVICE_IDS provided watch value %s is not a valid boolean", lfsIDSplit[2])
+					}
 				}
 				f.ServiceID = lfsIDSplit[1]
 				f.Watch = watch

--- a/internal/lagoon/fastly_test.go
+++ b/internal/lagoon/fastly_test.go
@@ -83,6 +83,48 @@ func TestGenerateFastlyConfiguration(t *testing.T) {
 				ServiceID: "abcdefg",
 			},
 		},
+		{
+			name: "test4",
+			args: args{
+				noCacheServiceID: "",
+				serviceID:        "",
+				route:            "",
+				secretPrefix:     "",
+				variables: []EnvironmentVariable{
+					{
+						Name:  "LAGOON_FASTLY_SERVICE_ID",
+						Value: "1234567",
+						Scope: "global",
+					},
+				},
+			},
+			provide: &Fastly{},
+			want: Fastly{
+				Watch:     true,
+				ServiceID: "1234567",
+			},
+		},
+		{
+			name: "test5",
+			args: args{
+				noCacheServiceID: "",
+				serviceID:        "",
+				route:            "",
+				secretPrefix:     "",
+				variables: []EnvironmentVariable{
+					{
+						Name:  "LAGOON_FASTLY_SERVICE_ID",
+						Value: "1234567:notabool",
+						Scope: "global",
+					},
+				},
+			},
+			provide: &Fastly{},
+			wantErr: true,
+			want: Fastly{
+				Watch: false,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/lagoon/routes.go
+++ b/internal/lagoon/routes.go
@@ -189,10 +189,10 @@ func GenerateRoutesV2(yamlRoutes *RoutesV2, routeMap map[string][]Route, variabl
 					// handle wildcards
 					if ingress.Wildcard != nil {
 						newRoute.Wildcard = ingress.Wildcard
-						if *newRoute.TLSAcme == true && *newRoute.Wildcard == true {
+						if *newRoute.TLSAcme && *newRoute.Wildcard {
 							return fmt.Errorf("Route %s has wildcard: true and tls-acme: true, this is not supported", newRoute.Domain)
 						}
-						if ingress.AlternativeNames != nil && *newRoute.Wildcard == true {
+						if ingress.AlternativeNames != nil && *newRoute.Wildcard {
 							return fmt.Errorf("Route %s has wildcard: true and alternativenames defined, this is not supported", newRoute.Domain)
 						}
 						newRoute.IngressName = fmt.Sprintf("wildcard-%s", newRoute.Domain)
@@ -221,7 +221,7 @@ func GenerateRoutesV2(yamlRoutes *RoutesV2, routeMap map[string][]Route, variabl
 			// generate the fastly configuration for this route
 			err := GenerateFastlyConfiguration(&newRoute.Fastly, "", newRoute.Fastly.ServiceID, newRoute.Domain, variables)
 			if err != nil {
-				//@TODO: error handling
+				return err
 			}
 
 			// validate the domain earlier and fail if it is invalid
@@ -364,10 +364,10 @@ func handleAPIRoute(defaultIngressClass string, apiRoute RouteV2) (RouteV2, erro
 	// handle wildcards
 	if apiRoute.Wildcard != nil {
 		routeAdd.Wildcard = apiRoute.Wildcard
-		if *routeAdd.TLSAcme == true && *routeAdd.Wildcard == true {
+		if *routeAdd.TLSAcme && *routeAdd.Wildcard {
 			return routeAdd, fmt.Errorf("Route %s has wildcard=true and tls-acme=true, this is not supported", routeAdd.Domain)
 		}
-		if apiRoute.AlternativeNames != nil && *routeAdd.Wildcard == true {
+		if apiRoute.AlternativeNames != nil && *routeAdd.Wildcard {
 			return routeAdd, fmt.Errorf("Route %s has wildcard=true and alternativenames defined, this is not supported", routeAdd.Domain)
 		}
 		apiRoute.IngressName = fmt.Sprintf("wildcard-%s", apiRoute.Domain)


### PR DESCRIPTION
Just a minor quality of life improvement for AIO that the watch status used in the `LAGOON_FASTLY_SERVICE_ID(S)` variable is optional and will default to `true`.