### PR TITLE
chore: fix name of feature to podspreadconstraints instead of antiaffinity

### DIFF
--- a/internal/generator/buildvalues.go
+++ b/internal/generator/buildvalues.go
@@ -81,7 +81,7 @@ type BuildValues struct {
 	SSHPrivateKey                 string                       `json:"sshPrivateKey"`
 	ForcePullImages               []string                     `json:"forcePullImages"`
 	Volumes                       []ComposeVolume              `json:"volumes,omitempty" description:"stores any additional persistent volume definitions"`
-	PodAntiAffinity               bool                         `json:"podAntiAffinity"`
+	PodSpreadConstraints          bool                         `json:"podSpreadConstraints"`
 }
 
 type Resources struct {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -268,9 +268,9 @@ func NewGenerator(
 	}
 
 	// feature to enable pod antiaffinity on deployments
-	podAntiAffinity := CheckFeatureFlag("POD_SPREADCONSTRAINTS", buildValues.EnvironmentVariables, false)
-	if podAntiAffinity == "enabled" {
-		buildValues.PodAntiAffinity = true
+	podSpreadConstraints := CheckFeatureFlag("POD_SPREADCONSTRAINTS", buildValues.EnvironmentVariables, false)
+	if podSpreadConstraints == "enabled" {
+		buildValues.PodSpreadConstraints = true
 	}
 
 	// check for readwritemany to readwriteonce flag, disabled by default

--- a/internal/templating/services/templates_deployment.go
+++ b/internal/templating/services/templates_deployment.go
@@ -138,10 +138,7 @@ func GenerateDeploymentTemplate(
 					}
 				}
 			}
-			if buildValues.PodAntiAffinity {
-				// if deployment.Spec.Template.Spec.Affinity == nil {
-				// 	deployment.Spec.Template.Spec.Affinity = &corev1.Affinity{}
-				// }
+			if buildValues.PodSpreadConstraints {
 				deployment.Spec.Template.Spec.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{
 					{
 						MaxSkew:           1,
@@ -181,48 +178,6 @@ func GenerateDeploymentTemplate(
 						},
 					},
 				}
-				// deployment.Spec.Template.Spec.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{
-				// 	PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-				// 		{
-				// 			Weight: 100,
-				// 			PodAffinityTerm: corev1.PodAffinityTerm{
-				// 				TopologyKey: "kubernetes.io/hostname",
-				// 				LabelSelector: &metav1.LabelSelector{
-				// 					MatchExpressions: []metav1.LabelSelectorRequirement{
-				// 						{
-				// 							Key:      "app.kubernetes.io/name",
-				// 							Operator: metav1.LabelSelectorOpIn,
-				// 							Values: []string{
-				// 								serviceTypeValues.Name,
-				// 							},
-				// 						},
-				// 						{
-				// 							Key:      "app.kubernetes.io/instance",
-				// 							Operator: metav1.LabelSelectorOpIn,
-				// 							Values: []string{
-				// 								serviceValues.OverrideName,
-				// 							},
-				// 						},
-				// 						{
-				// 							Key:      "lagoon.sh/project",
-				// 							Operator: metav1.LabelSelectorOpIn,
-				// 							Values: []string{
-				// 								buildValues.Project,
-				// 							},
-				// 						},
-				// 						{
-				// 							Key:      "lagoon.sh/environment",
-				// 							Operator: metav1.LabelSelectorOpIn,
-				// 							Values: []string{
-				// 								buildValues.Environment,
-				// 							},
-				// 						},
-				// 					},
-				// 				},
-				// 			},
-				// 		},
-				// 	},
-				// }
 			}
 
 			for key, value := range additionalLabels {

--- a/internal/templating/services/templates_deployment_test.go
+++ b/internal/templating/services/templates_deployment_test.go
@@ -882,7 +882,7 @@ func TestGenerateDeploymentTemplate(t *testing.T) {
 					ImageReferences: map[string]string{
 						"myservice": "harbor.example.com/example-project/environment-name/myservice@latest",
 					},
-					PodAntiAffinity: true,
+					PodSpreadConstraints: true,
 					Services: []generator.ServiceValues{
 						{
 							Name:             "myservice",


### PR DESCRIPTION
Just a small renaming of the variables used for podspreadconstraints