### PR TITLE
chore: remove open/elasticsearch init container

### DIFF
--- a/internal/servicetypes/elasticsearch.go
+++ b/internal/servicetypes/elasticsearch.go
@@ -3,7 +3,6 @@ package servicetypes
 import (
 	"fmt"
 
-	"github.com/uselagoon/build-deploy-tool/internal/helpers"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -69,28 +68,6 @@ var elasticsearch = ServiceType{
 					corev1.ResourceCPU:    resource.MustParse("10m"),
 					corev1.ResourceMemory: resource.MustParse("10Mi"),
 				},
-			},
-		},
-	},
-	InitContainer: ServiceContainer{
-		Name: "set-max-map-count",
-		Command: []string{
-			"sh",
-			"-c",
-			`set -xe
-DESIRED="262144"
-CURRENT=$(sysctl -n vm.max_map_count)
-if [ "$DESIRED" -gt "$CURRENT" ]; then
-  sysctl -w vm.max_map_count=$DESIRED
-fi`,
-		},
-		Container: corev1.Container{
-			Name:            "set-max-map-count",
-			Image:           "library/busybox:latest",
-			ImagePullPolicy: corev1.PullIfNotPresent,
-			SecurityContext: &corev1.SecurityContext{
-				Privileged: helpers.BoolPtr(true),
-				RunAsUser:  helpers.Int64Ptr(0),
 			},
 		},
 	},

--- a/internal/servicetypes/opensearch.go
+++ b/internal/servicetypes/opensearch.go
@@ -3,7 +3,6 @@ package servicetypes
 import (
 	"fmt"
 
-	"github.com/uselagoon/build-deploy-tool/internal/helpers"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -69,28 +68,6 @@ var opensearch = ServiceType{
 					corev1.ResourceCPU:    resource.MustParse("10m"),
 					corev1.ResourceMemory: resource.MustParse("10Mi"),
 				},
-			},
-		},
-	},
-	InitContainer: ServiceContainer{
-		Name: "set-max-map-count",
-		Command: []string{
-			"sh",
-			"-c",
-			`set -xe
-DESIRED="262144"
-CURRENT=$(sysctl -n vm.max_map_count)
-if [ "$DESIRED" -gt "$CURRENT" ]; then
-  sysctl -w vm.max_map_count=$DESIRED
-fi`,
-		},
-		Container: corev1.Container{
-			Name:            "set-max-map-count",
-			Image:           "library/busybox:latest",
-			ImagePullPolicy: corev1.PullIfNotPresent,
-			SecurityContext: &corev1.SecurityContext{
-				Privileged: helpers.BoolPtr(true),
-				RunAsUser:  helpers.Int64Ptr(0),
 			},
 		},
 	},

--- a/internal/templating/test-resources/deployment/result-elasticsearch-1.yaml
+++ b/internal/templating/test-resources/deployment/result-elasticsearch-1.yaml
@@ -86,24 +86,6 @@ spec:
       enableServiceLinks: false
       imagePullSecrets:
       - name: lagoon-internal-registry-secret
-      initContainers:
-      - command:
-        - sh
-        - -c
-        - |-
-          set -xe
-          DESIRED="262144"
-          CURRENT=$(sysctl -n vm.max_map_count)
-          if [ "$DESIRED" -gt "$CURRENT" ]; then
-            sysctl -w vm.max_map_count=$DESIRED
-          fi
-        image: library/busybox:latest
-        imagePullPolicy: IfNotPresent
-        name: set-max-map-count
-        resources: {}
-        securityContext:
-          privileged: true
-          runAsUser: 0
       priorityClassName: lagoon-priority-production
       securityContext:
         fsGroup: 0
@@ -201,24 +183,6 @@ spec:
       enableServiceLinks: false
       imagePullSecrets:
       - name: lagoon-internal-registry-secret
-      initContainers:
-      - command:
-        - sh
-        - -c
-        - |-
-          set -xe
-          DESIRED="262144"
-          CURRENT=$(sysctl -n vm.max_map_count)
-          if [ "$DESIRED" -gt "$CURRENT" ]; then
-            sysctl -w vm.max_map_count=$DESIRED
-          fi
-        image: library/busybox:latest
-        imagePullPolicy: IfNotPresent
-        name: set-max-map-count
-        resources: {}
-        securityContext:
-          privileged: true
-          runAsUser: 0
       priorityClassName: lagoon-priority-production
       securityContext:
         fsGroup: 0

--- a/internal/templating/test-resources/deployment/result-opensearch-1.yaml
+++ b/internal/templating/test-resources/deployment/result-opensearch-1.yaml
@@ -86,24 +86,6 @@ spec:
       enableServiceLinks: false
       imagePullSecrets:
       - name: lagoon-internal-registry-secret
-      initContainers:
-      - command:
-        - sh
-        - -c
-        - |-
-          set -xe
-          DESIRED="262144"
-          CURRENT=$(sysctl -n vm.max_map_count)
-          if [ "$DESIRED" -gt "$CURRENT" ]; then
-            sysctl -w vm.max_map_count=$DESIRED
-          fi
-        image: library/busybox:latest
-        imagePullPolicy: IfNotPresent
-        name: set-max-map-count
-        resources: {}
-        securityContext:
-          privileged: true
-          runAsUser: 0
       priorityClassName: lagoon-priority-production
       securityContext:
         fsGroup: 0
@@ -201,24 +183,6 @@ spec:
       enableServiceLinks: false
       imagePullSecrets:
       - name: lagoon-internal-registry-secret
-      initContainers:
-      - command:
-        - sh
-        - -c
-        - |-
-          set -xe
-          DESIRED="262144"
-          CURRENT=$(sysctl -n vm.max_map_count)
-          if [ "$DESIRED" -gt "$CURRENT" ]; then
-            sysctl -w vm.max_map_count=$DESIRED
-          fi
-        image: library/busybox:latest
-        imagePullPolicy: IfNotPresent
-        name: set-max-map-count
-        resources: {}
-        securityContext:
-          privileged: true
-          runAsUser: 0
       priorityClassName: lagoon-priority-production
       securityContext:
         fsGroup: 0

--- a/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-opensearch.yaml
+++ b/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-opensearch.yaml
@@ -86,24 +86,6 @@ spec:
       enableServiceLinks: false
       imagePullSecrets:
       - name: lagoon-internal-registry-secret
-      initContainers:
-      - command:
-        - sh
-        - -c
-        - |-
-          set -xe
-          DESIRED="262144"
-          CURRENT=$(sysctl -n vm.max_map_count)
-          if [ "$DESIRED" -gt "$CURRENT" ]; then
-            sysctl -w vm.max_map_count=$DESIRED
-          fi
-        image: library/busybox:latest
-        imagePullPolicy: IfNotPresent
-        name: set-max-map-count
-        resources: {}
-        securityContext:
-          privileged: true
-          runAsUser: 0
       priorityClassName: lagoon-priority-production
       securityContext:
         fsGroup: 0

--- a/internal/testdata/complex/service-templates/test8-multiple-services/deployment-opensearch-2.yaml
+++ b/internal/testdata/complex/service-templates/test8-multiple-services/deployment-opensearch-2.yaml
@@ -86,24 +86,6 @@ spec:
       enableServiceLinks: false
       imagePullSecrets:
       - name: lagoon-internal-registry-secret
-      initContainers:
-      - command:
-        - sh
-        - -c
-        - |-
-          set -xe
-          DESIRED="262144"
-          CURRENT=$(sysctl -n vm.max_map_count)
-          if [ "$DESIRED" -gt "$CURRENT" ]; then
-            sysctl -w vm.max_map_count=$DESIRED
-          fi
-        image: library/busybox:latest
-        imagePullPolicy: IfNotPresent
-        name: set-max-map-count
-        resources: {}
-        securityContext:
-          privileged: true
-          runAsUser: 0
       priorityClassName: lagoon-priority-production
       securityContext:
         fsGroup: 0


### PR DESCRIPTION
With https://github.com/uselagoon/lagoon-charts/pull/700 we should be able to remove the `initContainer` that sets sysctl values with privileged access. 

The daemonset in the chart will do it instead, best yet would be the underlying k8s nodes having this value increased by default though.