### PR TITLE
fix: remove unused remnants of custom rollout support

### DIFF
--- a/legacy/build-deploy-docker-compose.sh
+++ b/legacy/build-deploy-docker-compose.sh
@@ -1499,14 +1499,6 @@ do
   SERVICE_NAME=${SERVICE_TYPES_ENTRY_SPLIT[0]}
   SERVICE_TYPE=${SERVICE_TYPES_ENTRY_SPLIT[1]}
 
-  SERVICE_ROLLOUT_TYPE=$(cat $DOCKER_COMPOSE_YAML | shyaml get-value services.${SERVICE_NAME}.labels.lagoon\\.rollout deployment)
-
-  # Allow the rollout type to be overriden by environment in .lagoon.yml
-  ENVIRONMENT_SERVICE_ROLLOUT_TYPE=$(cat .lagoon.yml | shyaml get-value environments.${BRANCH//./\\.}.rollouts.${SERVICE_NAME} false)
-  if [ ! $ENVIRONMENT_SERVICE_ROLLOUT_TYPE == "false" ]; then
-    SERVICE_ROLLOUT_TYPE=$ENVIRONMENT_SERVICE_ROLLOUT_TYPE
-  fi
-
   # check if this service is a dbaas service and transform the service_type accordingly
   for DBAAS_ENTRY in "${DBAAS[@]}"
   do
@@ -1518,19 +1510,9 @@ do
     fi
   done
 
-  if [ $SERVICE_TYPE == "mariadb-dbaas" ]; then
-
+  if [[ $SERVICE_TYPE == *"-dbaas" ]]; then
     echo "nothing to monitor for $SERVICE_TYPE"
-
-  elif [ $SERVICE_TYPE == "postgres-dbaas" ]; then
-
-    echo "nothing to monitor for $SERVICE_TYPE"
-
-  elif [ $SERVICE_TYPE == "mongodb-dbaas" ]; then
-
-    echo "nothing to monitor for $SERVICE_TYPE"
-
-  elif [ ! $SERVICE_ROLLOUT_TYPE == "false" ]; then
+  else
     . /kubectl-build-deploy/scripts/exec-monitor-deploy.sh
   fi
 done


### PR DESCRIPTION
We used to support custom deployment templates and rollouts under Openshift. I believe this code is some leftovers of that era that was not removed as part of an [old cleanup commit](https://github.com/uselagoon/lagoon/commit/3fdb17baee346f967bafd789f4992daca9cf53b1).

While it is still technically possible for a project to set the rollout type to `false`, and disable rollout monitoring for that service, I can't think of a valid reason why we should continue to support this.

Already have a PR to document it as deprecated https://github.com/uselagoon/lagoon/pull/3871.