### PR TITLE
chore: modify name of image built locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,21 +6,27 @@ GOARCH=amd64
 PKG=github.com/uselagoon/build-deploy-tool
 LDFLAGS=-w -s -X ${PKG}/cmd.bdtVersion=${VERSION} -X ${PKG}/cmd.bdtBuild=${BUILD} -X "${PKG}/cmd.goVersion=${GO_VER}"
 
+.PHONY: test
 test: fmt vet
 	go clean -testcache && go test -v ./...
 
+.PHONY: fmt
 fmt:
 	go fmt ./...
 
+.PHONY: vet
 vet:
 	go vet ./...
 
+.PHONY: run
 run: fmt vet
 	go run ./main.go
 
+.PHONY: build
 build: fmt vet
 	CGO_ENABLED=0 go build -ldflags '${LDFLAGS}' -v
 
+.PHONY: docker-build
 docker-build:
-	DOCKER_BUILDKIT=1 docker build --pull --build-arg GO_VER=${GO_VER} --build-arg VERSION=${VERSION} --build-arg BUILD=${BUILD} --rm -f Dockerfile -t build-deploy-image:local .
-	docker run --entrypoint /bin/bash build-deploy-image:local -c 'build-deploy-tool version'
+	DOCKER_BUILDKIT=1 docker build --pull --build-arg GO_VER=${GO_VER} --build-arg VERSION=${VERSION} --build-arg BUILD=${BUILD} --rm -f Dockerfile -t lagoon/build-deploy-image:local .
+	docker run --entrypoint /bin/bash lagoon/build-deploy-image:local -c 'build-deploy-tool version'


### PR DESCRIPTION
Changes the name of the built image to `lagoon/build-deploy-image:local` instead of just `build-deploy-image:local`, also some minor adjustments to the makefile.