### PR TITLE
fix: use docker library to create registry secret authconfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/compose-spec/compose-go v1.2.7
 	github.com/cxmcc/unixsums v0.0.0-20131125091133-89564297d82f
 	github.com/distribution/reference v0.6.0
+	github.com/docker/cli v27.5.1+incompatible
 	github.com/drone/envsubst v1.0.3
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
@@ -31,6 +32,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/distribution/v3 v3.0.0-20210316161203-a01c71e2477e // indirect
+	github.com/docker/docker-credential-helpers v0.8.2 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,11 @@ github.com/distribution/distribution/v3 v3.0.0-20210316161203-a01c71e2477e/go.mo
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
+github.com/docker/cli v27.5.1+incompatible h1:JB9cieUT9YNiMITtIsguaN55PLOHhBSz3LKVc6cqWaY=
+github.com/docker/cli v27.5.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
+github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=

--- a/internal/templating/template_registrysecret_test.go
+++ b/internal/templating/template_registrysecret_test.go
@@ -14,10 +14,11 @@ func TestGenerateRegistrySecretTemplate(t *testing.T) {
 		buildValues generator.BuildValues
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    string
-		wantErr bool
+		name        string
+		description string
+		args        args
+		want        string
+		wantErr     bool
 	}{
 		{
 			name: "test1",
@@ -58,6 +59,46 @@ func TestGenerateRegistrySecretTemplate(t *testing.T) {
 				},
 			},
 			want: "test-resources/regsecret/registry-secret1.yaml",
+		}, {
+			name:        "test2",
+			description: "test a password with quotes",
+			args: args{
+				buildValues: generator.BuildValues{
+					Project:         "example-project",
+					Environment:     "environment-name",
+					EnvironmentType: "production",
+					Namespace:       "myexample-project-environment-name",
+					BuildType:       "branch",
+					LagoonVersion:   "v2.x.x",
+					Kubernetes:      "generator.local",
+					Branch:          "environment-name",
+					Services: []generator.ServiceValues{
+						{
+							Name:             "myservice",
+							OverrideName:     "myservice",
+							Type:             "basic",
+							DBaaSEnvironment: "development",
+						},
+						{
+							Name:             "myservice-po",
+							OverrideName:     "myservice-po",
+							Type:             "basic",
+							DBaaSEnvironment: "development",
+							ServicePort:      8080,
+						},
+					},
+					ContainerRegistry: []generator.ContainerRegistry{
+						{
+							Name:       "secret2",
+							SecretName: "internal-registry-secret-secret2",
+							Username:   "username",
+							Password:   `pass"word`,
+							URL:        "my.registry.example.com",
+						},
+					},
+				},
+			},
+			want: "test-resources/regsecret/registry-secret2.yaml",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/templating/test-resources/regsecret/registry-secret2.yaml
+++ b/internal/templating/test-resources/regsecret/registry-secret2.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJteS5yZWdpc3RyeS5leGFtcGxlLmNvbSI6eyJ1c2VybmFtZSI6InVzZXJuYW1lIiwicGFzc3dvcmQiOiJwYXNzXCJ3b3JkIiwiYXV0aCI6ImRYTmxjbTVoYldVNmNHRnpjeUozYjNKayJ9fX0=
+kind: Secret
+metadata:
+  annotations:
+    lagoon.sh/branch: environment-name
+    lagoon.sh/version: v2.x.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: internal-registry-secret
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: secret2
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: environment-name
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/template: internal-registry-secret-0.1.0
+  name: internal-registry-secret-secret2
+type: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
Fixes a bug in the registry secret generation that doesn't properly escape the payload. Now uses the docker authconfig type to create and json marshal function to convert to byte array for the secret.