### PR TITLE
refactor: add retry workaround for image builds

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -374,7 +374,7 @@ func NewGenerator(
 
 	// get any variables from the API here that could be used to influence a build or services within the environment
 	// collect docker buildkit value
-	dockerBuildKit, _ := lagoon.GetLagoonVariable("DOCKER_BUILDKIT", []string{"build"}, buildValues.EnvironmentVariables)
+	dockerBuildKit, _ := lagoon.GetLagoonVariable("DOCKER_BUILDKIT", []string{"build", "global"}, buildValues.EnvironmentVariables)
 	if dockerBuildKit != nil {
 		bk, _ := strconv.ParseBool(dockerBuildKit.Value)
 		buildValues.DockerBuildKit = &bk


### PR DESCRIPTION
This adds a simple retry logic to capture a weird buildkit related layer issue. While we're working to resolve the actual issue and understand the root cause, this retry logic should help to reduce the instance of failures encountered by forcing a subsequent build to build with the `--no-cache` flag.