### PR TITLE
fix: use the k8upv2 feature flag correctly

### DIFF
--- a/cmd/template_backups_test.go
+++ b/cmd/template_backups_test.go
@@ -184,13 +184,18 @@ func TestBackupTemplateGeneration(t *testing.T) {
 					ProjectName:     "example-project",
 					EnvironmentName: "main",
 					Branch:          "main",
-					K8UPVersion:     "v2",
 					LagoonYAML:      "internal/testdata/complex/lagoon.yml",
 					ProjectVariables: []lagoon.EnvironmentVariable{
 						{
 							Name:  "LAGOON_FEATURE_FLAG_IMAGECACHE_REGISTRY",
 							Value: "imagecache.example.com",
 							Scope: "global",
+						},
+					},
+					BuildPodVariables: []helpers.EnvironmentVariable{
+						{
+							Name:  "LAGOON_FEATURE_FLAG_DEFAULT_K8UP_V2",
+							Value: "enabled",
 						},
 					},
 				}, true),
@@ -204,13 +209,18 @@ func TestBackupTemplateGeneration(t *testing.T) {
 					ProjectName:     "example-project",
 					EnvironmentName: "main",
 					Branch:          "main",
-					K8UPVersion:     "v2",
 					LagoonYAML:      "internal/testdata/node/lagoon.nostorage.yml",
 					ProjectVariables: []lagoon.EnvironmentVariable{
 						{
 							Name:  "LAGOON_FEATURE_FLAG_IMAGECACHE_REGISTRY",
 							Value: "imagecache.example.com",
 							Scope: "global",
+						},
+					},
+					BuildPodVariables: []helpers.EnvironmentVariable{
+						{
+							Name:  "LAGOON_FEATURE_FLAG_DEFAULT_K8UP_V2",
+							Value: "enabled",
 						},
 					},
 				}, true),
@@ -273,12 +283,17 @@ func TestBackupTemplateGeneration(t *testing.T) {
 					Branch:          "main",
 					EnvironmentType: "production",
 					LagoonYAML:      "internal/testdata/node/lagoon.yml",
-					K8UPVersion:     "v2",
 					ProjectVariables: []lagoon.EnvironmentVariable{
 						{
 							Name:  "LAGOON_FEATURE_FLAG_ROOTLESS_WORKLOAD",
 							Value: "enabled",
 							Scope: "global",
+						},
+					},
+					BuildPodVariables: []helpers.EnvironmentVariable{
+						{
+							Name:  "LAGOON_FEATURE_FLAG_DEFAULT_K8UP_V2",
+							Value: "enabled",
 						},
 					},
 				}, true),
@@ -295,7 +310,6 @@ func TestBackupTemplateGeneration(t *testing.T) {
 					Branch:          "main",
 					EnvironmentType: "production",
 					LagoonYAML:      "internal/testdata/node/lagoon.yml",
-					K8UPVersion:     "v2",
 					ProjectVariables: []lagoon.EnvironmentVariable{
 						{
 							Name:  "LAGOON_FEATURE_FLAG_ROOTLESS_WORKLOAD",
@@ -306,6 +320,12 @@ func TestBackupTemplateGeneration(t *testing.T) {
 							Name:  "LAGOON_FEATURE_FLAG_FS_ON_ROOT_MISMATCH",
 							Value: "enabled",
 							Scope: "global",
+						},
+					},
+					BuildPodVariables: []helpers.EnvironmentVariable{
+						{
+							Name:  "LAGOON_FEATURE_FLAG_DEFAULT_K8UP_V2",
+							Value: "enabled",
 						},
 					},
 				}, true),

--- a/cmd/template_lagoonservices_test.go
+++ b/cmd/template_lagoonservices_test.go
@@ -583,6 +583,28 @@ func TestTemplateLagoonServices(t *testing.T) {
 			templatePath: "testoutput",
 			want:         "internal/testdata/complex/service-templates/test-complex-persistent-names",
 		},
+		{
+			name:        "test-redis-persistent-k8upv2",
+			description: "tests a basic deployment with a redis-persistent with k8up v2 featureflag",
+			args: testdata.GetSeedData(
+				testdata.TestData{
+					ProjectName:     "example-project",
+					EnvironmentName: "main",
+					Branch:          "main",
+					LagoonYAML:      "internal/testdata/complex/lagoon.redis-persistent.yml",
+					ImageReferences: map[string]string{
+						"redis": "harbor.example/example-project/main/redis@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8",
+					},
+					BuildPodVariables: []helpers.EnvironmentVariable{
+						{
+							Name:  "LAGOON_FEATURE_FLAG_DEFAULT_K8UP_V2",
+							Value: "enabled",
+						},
+					},
+				}, true),
+			templatePath: "testoutput",
+			want:         "internal/testdata/complex/service-templates/test-redis-persistent-k8upv2",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -136,8 +136,13 @@ func NewGenerator(
 		return nil, err
 	}
 
-	buildValues.Backup.K8upVersion = helpers.GetEnv("K8UP_VERSION", generator.BackupConfiguration.K8upVersion, generator.Debug)
-
+	// default to k8up v1 (backup.appuio.ch/v1alpha1) version
+	buildValues.Backup.K8upVersion = "v1"
+	k8upV2 := CheckFeatureFlag("K8UP_V2", buildValues.EnvironmentVariables, false)
+	if k8upV2 == "enabled" {
+		// if k8upv2 (k8up.io/v1) version is specified by remote, set that here
+		buildValues.Backup.K8upVersion = "v2"
+	}
 	// get the project and environment variables
 	projectVariables := helpers.GetEnv("LAGOON_PROJECT_VARIABLES", generator.ProjectVariables, generator.Debug)
 	environmentVariables := helpers.GetEnv("LAGOON_ENVIRONMENT_VARIABLES", generator.EnvironmentVariables, generator.Debug)

--- a/internal/testdata/complex/docker-compose.redis-persistent.yml
+++ b/internal/testdata/complex/docker-compose.redis-persistent.yml
@@ -1,0 +1,8 @@
+version: '2'
+services:
+  redis:
+    image: uselagoon/redis:latest
+    labels:
+      lagoon.type: redis-persistent
+    ports:
+      - '6379'

--- a/internal/testdata/complex/lagoon.redis-persistent.yml
+++ b/internal/testdata/complex/lagoon.redis-persistent.yml
@@ -1,0 +1,10 @@
+docker-compose-yaml: internal/testdata/complex/docker-compose.redis-persistent.yml
+
+environment_variables:
+  git_sha: "true"
+
+environments:
+  main:
+    routes:
+      - node:
+          - example.com

--- a/internal/testdata/complex/service-templates/test-redis-persistent-k8upv2/deployment-redis.yaml
+++ b/internal/testdata/complex/service-templates/test-redis-persistent-k8upv2/deployment-redis.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: redis
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: redis-persistent
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: redis
+    lagoon.sh/service-type: redis-persistent
+    lagoon.sh/template: redis-persistent-0.1.0
+  name: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: redis
+      app.kubernetes.io/name: redis-persistent
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        k8up.io/backupcommand: /bin/sh -c "timeout 5400 tar -cf - -C /data ."
+        k8up.io/file-extension: .redis.tar
+        lagoon.sh/branch: main
+        lagoon.sh/configMapSha: abcdefg1234567890
+        lagoon.sh/version: v2.7.x
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: redis
+        app.kubernetes.io/managed-by: build-deploy-tool
+        app.kubernetes.io/name: redis-persistent
+        lagoon.sh/buildType: branch
+        lagoon.sh/environment: main
+        lagoon.sh/environmentType: production
+        lagoon.sh/project: example-project
+        lagoon.sh/service: redis
+        lagoon.sh/service-type: redis-persistent
+        lagoon.sh/template: redis-persistent-0.1.0
+    spec:
+      containers:
+      - env:
+        - name: LAGOON_GIT_SHA
+          value: abcdefg123456
+        - name: CRONJOBS
+        - name: SERVICE_NAME
+          value: redis
+        envFrom:
+        - configMapRef:
+            name: lagoon-env
+        image: harbor.example/example-project/main/redis@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8
+        imagePullPolicy: Always
+        livenessProbe:
+          initialDelaySeconds: 120
+          tcpSocket:
+            port: 6379
+          timeoutSeconds: 1
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: 6379-tcp
+          protocol: TCP
+        readinessProbe:
+          initialDelaySeconds: 1
+          tcpSocket:
+            port: 6379
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext: {}
+        volumeMounts:
+        - mountPath: /data
+          name: redis
+      enableServiceLinks: false
+      imagePullSecrets:
+      - name: lagoon-internal-registry-secret
+      priorityClassName: lagoon-priority-production
+      volumes:
+      - name: redis
+        persistentVolumeClaim:
+          claimName: redis
+status: {}

--- a/internal/testdata/complex/service-templates/test-redis-persistent-k8upv2/pvc-redis.yaml
+++ b/internal/testdata/complex/service-templates/test-redis-persistent-k8upv2/pvc-redis.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    k8up.io/backup: "false"
+    k8up.syn.tools/backup: "false"
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: redis
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: redis-persistent
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: redis
+    lagoon.sh/service-type: redis-persistent
+    lagoon.sh/template: redis-persistent-0.1.0
+  name: redis
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+status: {}

--- a/internal/testdata/complex/service-templates/test-redis-persistent-k8upv2/service-redis.yaml
+++ b/internal/testdata/complex/service-templates/test-redis-persistent-k8upv2/service-redis.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: redis
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: redis-persistent
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: redis
+    lagoon.sh/service-type: redis-persistent
+    lagoon.sh/template: redis-persistent-0.1.0
+  name: redis
+spec:
+  ports:
+  - name: 6379-tcp
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app.kubernetes.io/instance: redis
+    app.kubernetes.io/name: redis-persistent
+status:
+  loadBalancer: {}


### PR DESCRIPTION
This fixes a bug with the check performed on which version of k8up should be used when adding annotations. Now correctly uses the feature flag.