### PR TITLE
chore: dont automount serviceaccount token

### DIFF
--- a/internal/templating/templates_cronjob.go
+++ b/internal/templating/templates_cronjob.go
@@ -99,6 +99,10 @@ func GenerateCronjobTemplate(
 						},
 					},
 				}
+
+				// disable automounted service account
+				cronjob.Spec.JobTemplate.Spec.Template.Spec.AutomountServiceAccountToken = helpers.BoolPtr(false)
+
 				cronjob.Spec.Schedule = nCronjob.Schedule
 				cronjob.Spec.ConcurrencyPolicy = batchv1.ForbidConcurrent
 				cronjob.Spec.SuccessfulJobsHistoryLimit = helpers.Int32Ptr(0)

--- a/internal/templating/templates_deployment.go
+++ b/internal/templating/templates_deployment.go
@@ -101,6 +101,9 @@ func GenerateDeploymentTemplate(
 			deployment.ObjectMeta.Labels = labels
 			deployment.ObjectMeta.Annotations = annotations
 
+			// disable automounted service account
+			deployment.Spec.Template.Spec.AutomountServiceAccountToken = helpers.BoolPtr(false)
+
 			if serviceValues.UseSpotInstances {
 				// handle spot instance label and affinity/tolerations/selectors
 				additionalLabels["lagoon.sh/spot"] = "true"

--- a/internal/templating/test-resources/cronjob/result-cli-1.yaml
+++ b/internal/templating/test-resources/cronjob/result-cli-1.yaml
@@ -45,6 +45,7 @@ spec:
             lagoon.sh/service-type: cli
             lagoon.sh/template: cli-0.1.0
         spec:
+          automountServiceAccountToken: false
           containers:
           - command:
             - /lagoon/cronjob.sh
@@ -138,6 +139,7 @@ spec:
             lagoon.sh/service-type: cli
             lagoon.sh/template: cli-0.1.0
         spec:
+          automountServiceAccountToken: false
           containers:
           - command:
             - /lagoon/cronjob.sh
@@ -231,6 +233,7 @@ spec:
             lagoon.sh/service-type: cli-persistent
             lagoon.sh/template: cli-persistent-0.1.0
         spec:
+          automountServiceAccountToken: false
           containers:
           - command:
             - /lagoon/cronjob.sh

--- a/internal/templating/test-resources/cronjob/result-cli-2.yaml
+++ b/internal/templating/test-resources/cronjob/result-cli-2.yaml
@@ -45,6 +45,7 @@ spec:
             lagoon.sh/service-type: cli
             lagoon.sh/template: cli-0.1.0
         spec:
+          automountServiceAccountToken: false
           containers:
           - command:
             - /lagoon/cronjob.sh
@@ -143,6 +144,7 @@ spec:
             lagoon.sh/service-type: cli
             lagoon.sh/template: cli-0.1.0
         spec:
+          automountServiceAccountToken: false
           containers:
           - command:
             - /lagoon/cronjob.sh
@@ -241,6 +243,7 @@ spec:
             lagoon.sh/service-type: cli-persistent
             lagoon.sh/template: cli-persistent-0.1.0
         spec:
+          automountServiceAccountToken: false
           containers:
           - command:
             - /lagoon/cronjob.sh

--- a/internal/templating/test-resources/cronjob/result-cli-3.yaml
+++ b/internal/templating/test-resources/cronjob/result-cli-3.yaml
@@ -45,6 +45,7 @@ spec:
             lagoon.sh/service-type: cli
             lagoon.sh/template: cli-0.1.0
         spec:
+          automountServiceAccountToken: false
           containers:
           - command:
             - /lagoon/cronjob.sh

--- a/internal/templating/test-resources/deployment/result-basic-1.yaml
+++ b/internal/templating/test-resources/deployment/result-basic-1.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: basic
         lagoon.sh/template: basic-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA
@@ -142,6 +143,7 @@ spec:
               - key: lagoon.sh/spot
                 operator: Exists
             weight: 1
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA
@@ -234,6 +236,7 @@ spec:
         lagoon.sh/service-type: basic-persistent
         lagoon.sh/template: basic-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA
@@ -326,6 +329,7 @@ spec:
         lagoon.sh/service-type: basic-persistent
         lagoon.sh/template: basic-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA
@@ -418,6 +422,7 @@ spec:
         lagoon.sh/service-type: basic-persistent
         lagoon.sh/template: basic-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/templating/test-resources/deployment/result-basic-2.yaml
+++ b/internal/templating/test-resources/deployment/result-basic-2.yaml
@@ -54,6 +54,7 @@ spec:
               - key: lagoon.sh/spot
                 operator: Exists
             weight: 1
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/templating/test-resources/deployment/result-basic-3.yaml
+++ b/internal/templating/test-resources/deployment/result-basic-3.yaml
@@ -54,6 +54,7 @@ spec:
               - key: lagoon.sh/spot
                 operator: Exists
             weight: 1
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/templating/test-resources/deployment/result-basic-4.yaml
+++ b/internal/templating/test-resources/deployment/result-basic-4.yaml
@@ -48,6 +48,7 @@ spec:
         lagoon.sh/service-type: basic-single
         lagoon.sh/template: basic-single-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/templating/test-resources/deployment/result-basic-5.yaml
+++ b/internal/templating/test-resources/deployment/result-basic-5.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: basic
         lagoon.sh/template: basic-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/templating/test-resources/deployment/result-cli-1.yaml
+++ b/internal/templating/test-resources/deployment/result-cli-1.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: cli
         lagoon.sh/template: cli-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA
@@ -134,6 +135,7 @@ spec:
         lagoon.sh/service-type: cli-persistent
         lagoon.sh/template: cli-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/templating/test-resources/deployment/result-elasticsearch-1.yaml
+++ b/internal/templating/test-resources/deployment/result-elasticsearch-1.yaml
@@ -48,6 +48,7 @@ spec:
         lagoon.sh/service-type: elasticsearch-persistent
         lagoon.sh/template: elasticsearch-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA
@@ -147,6 +148,7 @@ spec:
         lagoon.sh/service-type: elasticsearch-persistent
         lagoon.sh/template: elasticsearch-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/templating/test-resources/deployment/result-mariadb-1.yaml
+++ b/internal/templating/test-resources/deployment/result-mariadb-1.yaml
@@ -49,6 +49,7 @@ spec:
         lagoon.sh/service-type: mariadb-single
         lagoon.sh/template: mariadb-single-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/templating/test-resources/deployment/result-mariadb-2.yaml
+++ b/internal/templating/test-resources/deployment/result-mariadb-2.yaml
@@ -48,6 +48,7 @@ spec:
         lagoon.sh/service-type: mariadb-single
         lagoon.sh/template: mariadb-single-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/templating/test-resources/deployment/result-mongodb-1.yaml
+++ b/internal/templating/test-resources/deployment/result-mongodb-1.yaml
@@ -48,6 +48,7 @@ spec:
         lagoon.sh/service-type: mongodb-single
         lagoon.sh/template: mongodb-single-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/templating/test-resources/deployment/result-nginx-1.yaml
+++ b/internal/templating/test-resources/deployment/result-nginx-1.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: nginx-php
         lagoon.sh/template: nginx-php-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: NGINX_FASTCGI_PASS
@@ -180,6 +181,7 @@ spec:
         lagoon.sh/service-type: nginx-php-persistent
         lagoon.sh/template: nginx-php-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: NGINX_FASTCGI_PASS

--- a/internal/templating/test-resources/deployment/result-nginx-2.yaml
+++ b/internal/templating/test-resources/deployment/result-nginx-2.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: nginx-php
         lagoon.sh/template: nginx-php-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: NGINX_FASTCGI_PASS
@@ -173,6 +174,7 @@ spec:
         lagoon.sh/service-type: nginx-php-persistent
         lagoon.sh/template: nginx-php-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: NGINX_FASTCGI_PASS

--- a/internal/templating/test-resources/deployment/result-node-1.yaml
+++ b/internal/templating/test-resources/deployment/result-node-1.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: node
         lagoon.sh/template: node-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA
@@ -134,6 +135,7 @@ spec:
         lagoon.sh/service-type: node-persistent
         lagoon.sh/template: node-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/templating/test-resources/deployment/result-opensearch-1.yaml
+++ b/internal/templating/test-resources/deployment/result-opensearch-1.yaml
@@ -48,6 +48,7 @@ spec:
         lagoon.sh/service-type: opensearch-persistent
         lagoon.sh/template: opensearch-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA
@@ -147,6 +148,7 @@ spec:
         lagoon.sh/service-type: opensearch-persistent
         lagoon.sh/template: opensearch-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/templating/test-resources/deployment/result-postgres-1.yaml
+++ b/internal/templating/test-resources/deployment/result-postgres-1.yaml
@@ -49,6 +49,7 @@ spec:
         lagoon.sh/service-type: postgres-single
         lagoon.sh/template: postgres-single-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/templating/test-resources/deployment/result-postgres-single-1.yaml
+++ b/internal/templating/test-resources/deployment/result-postgres-single-1.yaml
@@ -49,6 +49,7 @@ spec:
         lagoon.sh/service-type: postgres-single
         lagoon.sh/template: postgres-single-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/templating/test-resources/deployment/result-python-1.yaml
+++ b/internal/templating/test-resources/deployment/result-python-1.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: python
         lagoon.sh/template: python-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA
@@ -134,6 +135,7 @@ spec:
         lagoon.sh/service-type: python-persistent
         lagoon.sh/template: python-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/templating/test-resources/deployment/result-rabbitmq-1.yaml
+++ b/internal/templating/test-resources/deployment/result-rabbitmq-1.yaml
@@ -48,6 +48,7 @@ spec:
         lagoon.sh/service-type: rabbitmq
         lagoon.sh/template: rabbitmq-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: RABBITMQ_NODENAME

--- a/internal/templating/test-resources/deployment/result-redis-1.yaml
+++ b/internal/templating/test-resources/deployment/result-redis-1.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: redis
         lagoon.sh/template: redis-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA
@@ -138,6 +139,7 @@ spec:
         lagoon.sh/service-type: redis-persistent
         lagoon.sh/template: redis-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/templating/test-resources/deployment/result-solr-1.yaml
+++ b/internal/templating/test-resources/deployment/result-solr-1.yaml
@@ -48,6 +48,7 @@ spec:
         lagoon.sh/service-type: solr-php-persistent
         lagoon.sh/template: solr-php-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/templating/test-resources/deployment/result-valkey-1.yaml
+++ b/internal/templating/test-resources/deployment/result-valkey-1.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: valkey
         lagoon.sh/template: valkey-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA
@@ -138,6 +139,7 @@ spec:
         lagoon.sh/service-type: valkey-persistent
         lagoon.sh/template: valkey-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: VALKEY_FLAVOR

--- a/internal/templating/test-resources/deployment/result-varnish-1.yaml
+++ b/internal/templating/test-resources/deployment/result-varnish-1.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: varnish
         lagoon.sh/template: varnish-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA
@@ -140,6 +141,7 @@ spec:
         lagoon.sh/service-type: varnish-persistent
         lagoon.sh/template: varnish-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/templating/test-resources/deployment/result-worker-1.yaml
+++ b/internal/templating/test-resources/deployment/result-worker-1.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: worker
         lagoon.sh/template: worker-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA
@@ -139,6 +140,7 @@ spec:
         lagoon.sh/service-type: worker-persistent
         lagoon.sh/template: worker-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/basic/service-templates/test-basic-persistent-name/deployment-basic.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-persistent-name/deployment-basic.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: basic-persistent
         lagoon.sh/template: basic-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/basic/service-templates/test-basic-persistent-names/deployment-basic.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-persistent-names/deployment-basic.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: basic-persistent
         lagoon.sh/template: basic-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/basic/service-templates/test-basic-persistent-names/deployment-basic2.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-persistent-names/deployment-basic2.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: basic-persistent
         lagoon.sh/template: basic-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/basic/service-templates/test-basic-single-k8upv2/deployment-basic.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-single-k8upv2/deployment-basic.yaml
@@ -48,6 +48,7 @@ spec:
         lagoon.sh/service-type: basic-single
         lagoon.sh/template: basic-single-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/basic/service-templates/test-basic-spot-affinity/deployment-node.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-spot-affinity/deployment-node.yaml
@@ -54,6 +54,7 @@ spec:
               - key: lagoon.sh/spot
                 operator: Exists
             weight: 1
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/basic/service-templates/test1-basic-deployment/deployment-node.yaml
+++ b/internal/testdata/basic/service-templates/test1-basic-deployment/deployment-node.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: basic
         lagoon.sh/template: basic-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/basic/service-templates/test10-basic-no-native-cronjobs/deployment-node.yaml
+++ b/internal/testdata/basic/service-templates/test10-basic-no-native-cronjobs/deployment-node.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: basic
         lagoon.sh/template: basic-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/basic/service-templates/test11-basic-polysite-cronjobs/cronjob-cronjob-node-some-other-drush-cron.yaml
+++ b/internal/testdata/basic/service-templates/test11-basic-polysite-cronjobs/cronjob-cronjob-node-some-other-drush-cron.yaml
@@ -45,6 +45,7 @@ spec:
             lagoon.sh/service-type: basic
             lagoon.sh/template: basic-0.1.0
         spec:
+          automountServiceAccountToken: false
           containers:
           - command:
             - /lagoon/cronjob.sh

--- a/internal/testdata/basic/service-templates/test11-basic-polysite-cronjobs/deployment-node.yaml
+++ b/internal/testdata/basic/service-templates/test11-basic-polysite-cronjobs/deployment-node.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: basic
         lagoon.sh/template: basic-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/basic/service-templates/test12-basic-persistent-custom-volumes/deployment-node.yaml
+++ b/internal/testdata/basic/service-templates/test12-basic-persistent-custom-volumes/deployment-node.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: basic-persistent
         lagoon.sh/template: basic-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/basic/service-templates/test13-basic-custom-volumes/deployment-node.yaml
+++ b/internal/testdata/basic/service-templates/test13-basic-custom-volumes/deployment-node.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: basic
         lagoon.sh/template: basic-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/basic/service-templates/test15-basic-custom-volume-no-backup/deployment-node.yaml
+++ b/internal/testdata/basic/service-templates/test15-basic-custom-volume-no-backup/deployment-node.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: basic
         lagoon.sh/template: basic-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/basic/service-templates/test3-funky-pvcs/deployment-lnd.yaml
+++ b/internal/testdata/basic/service-templates/test3-funky-pvcs/deployment-lnd.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: basic-persistent
         lagoon.sh/template: basic-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/basic/service-templates/test3-funky-pvcs/deployment-thunderhub.yaml
+++ b/internal/testdata/basic/service-templates/test3-funky-pvcs/deployment-thunderhub.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: basic-persistent
         lagoon.sh/template: basic-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/basic/service-templates/test3-funky-pvcs/deployment-tor.yaml
+++ b/internal/testdata/basic/service-templates/test3-funky-pvcs/deployment-tor.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: basic
         lagoon.sh/template: basic-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/basic/service-templates/test4-basic-worker/deployment-lnd.yaml
+++ b/internal/testdata/basic/service-templates/test4-basic-worker/deployment-lnd.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: basic-persistent
         lagoon.sh/template: basic-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/basic/service-templates/test4-basic-worker/deployment-tor.yaml
+++ b/internal/testdata/basic/service-templates/test4-basic-worker/deployment-tor.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: worker-persistent
         lagoon.sh/template: worker-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/basic/service-templates/test5-basic-promote/deployment-node.yaml
+++ b/internal/testdata/basic/service-templates/test5-basic-promote/deployment-node.yaml
@@ -42,6 +42,7 @@ spec:
         lagoon.sh/service-type: basic
         lagoon.sh/template: basic-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/basic/service-templates/test6-basic-networkpolicy/deployment-node.yaml
+++ b/internal/testdata/basic/service-templates/test6-basic-networkpolicy/deployment-node.yaml
@@ -48,6 +48,7 @@ spec:
         lagoon.sh/service-type: basic
         lagoon.sh/template: basic-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/basic/service-templates/test7-basic-dynamic-secrets/deployment-node.yaml
+++ b/internal/testdata/basic/service-templates/test7-basic-dynamic-secrets/deployment-node.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: basic
         lagoon.sh/template: basic-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-cli.yaml
+++ b/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-cli.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: cli-persistent
         lagoon.sh/template: cli-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-gotenberg.yaml
+++ b/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-gotenberg.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: basic
         lagoon.sh/template: basic-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-nginx.yaml
+++ b/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-nginx.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: nginx-php-persistent
         lagoon.sh/template: nginx-php-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: NGINX_FASTCGI_PASS

--- a/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-opensearch.yaml
+++ b/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-opensearch.yaml
@@ -48,6 +48,7 @@ spec:
         lagoon.sh/service-type: opensearch-persistent
         lagoon.sh/template: opensearch-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-queue-worker-entity-index.yaml
+++ b/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-queue-worker-entity-index.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: worker-persistent
         lagoon.sh/template: worker-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-queue-worker-priority-high.yaml
+++ b/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-queue-worker-priority-high.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: worker-persistent
         lagoon.sh/template: worker-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-queue-worker-priority-instant.yaml
+++ b/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-queue-worker-priority-instant.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: worker-persistent
         lagoon.sh/template: worker-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-queue-worker-priority-low.yaml
+++ b/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-queue-worker-priority-low.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: worker-persistent
         lagoon.sh/template: worker-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-queue-worker-priority-medium.yaml
+++ b/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-queue-worker-priority-medium.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: worker-persistent
         lagoon.sh/template: worker-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-rabbitmq.yaml
+++ b/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-rabbitmq.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: basic-persistent
         lagoon.sh/template: basic-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-redis-persist.yaml
+++ b/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-redis-persist.yaml
@@ -48,6 +48,7 @@ spec:
         lagoon.sh/service-type: redis-persistent
         lagoon.sh/template: redis-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-redis-session.yaml
+++ b/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-redis-session.yaml
@@ -48,6 +48,7 @@ spec:
         lagoon.sh/service-type: redis-persistent
         lagoon.sh/template: redis-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-redis.yaml
+++ b/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-redis.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: redis
         lagoon.sh/template: redis-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test-redis-persistent-k8upv2/deployment-redis.yaml
+++ b/internal/testdata/complex/service-templates/test-redis-persistent-k8upv2/deployment-redis.yaml
@@ -47,6 +47,7 @@ spec:
         lagoon.sh/service-type: redis-persistent
         lagoon.sh/template: redis-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test14-complex-custom-volumes/deployment-cli.yaml
+++ b/internal/testdata/complex/service-templates/test14-complex-custom-volumes/deployment-cli.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: cli-persistent
         lagoon.sh/template: cli-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test14-complex-custom-volumes/deployment-mariadb.yaml
+++ b/internal/testdata/complex/service-templates/test14-complex-custom-volumes/deployment-mariadb.yaml
@@ -49,6 +49,7 @@ spec:
         lagoon.sh/service-type: mariadb-single
         lagoon.sh/template: mariadb-single-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test14-complex-custom-volumes/deployment-nginx.yaml
+++ b/internal/testdata/complex/service-templates/test14-complex-custom-volumes/deployment-nginx.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: nginx-php-persistent
         lagoon.sh/template: nginx-php-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: NGINX_FASTCGI_PASS

--- a/internal/testdata/complex/service-templates/test2-nginx-php/cronjob-cronjob-cli-drush-cron2.yaml
+++ b/internal/testdata/complex/service-templates/test2-nginx-php/cronjob-cronjob-cli-drush-cron2.yaml
@@ -45,6 +45,7 @@ spec:
             lagoon.sh/service-type: cli-persistent
             lagoon.sh/template: cli-persistent-0.1.0
         spec:
+          automountServiceAccountToken: false
           containers:
           - command:
             - /lagoon/cronjob.sh

--- a/internal/testdata/complex/service-templates/test2-nginx-php/deployment-cli.yaml
+++ b/internal/testdata/complex/service-templates/test2-nginx-php/deployment-cli.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: cli-persistent
         lagoon.sh/template: cli-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test2-nginx-php/deployment-nginx-php.yaml
+++ b/internal/testdata/complex/service-templates/test2-nginx-php/deployment-nginx-php.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: nginx-php-persistent
         lagoon.sh/template: nginx-php-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: NGINX_FASTCGI_PASS

--- a/internal/testdata/complex/service-templates/test2-nginx-php/deployment-redis.yaml
+++ b/internal/testdata/complex/service-templates/test2-nginx-php/deployment-redis.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: redis
         lagoon.sh/template: redis-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test2-nginx-php/deployment-varnish.yaml
+++ b/internal/testdata/complex/service-templates/test2-nginx-php/deployment-varnish.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: varnish
         lagoon.sh/template: varnish-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test2b-nginx-php/cronjob-cronjob-cli-drush-cron2.yaml
+++ b/internal/testdata/complex/service-templates/test2b-nginx-php/cronjob-cronjob-cli-drush-cron2.yaml
@@ -45,6 +45,7 @@ spec:
             lagoon.sh/service-type: cli-persistent
             lagoon.sh/template: cli-persistent-0.1.0
         spec:
+          automountServiceAccountToken: false
           containers:
           - command:
             - /lagoon/cronjob.sh

--- a/internal/testdata/complex/service-templates/test2b-nginx-php/deployment-cli.yaml
+++ b/internal/testdata/complex/service-templates/test2b-nginx-php/deployment-cli.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: cli-persistent
         lagoon.sh/template: cli-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test2b-nginx-php/deployment-nginx-php.yaml
+++ b/internal/testdata/complex/service-templates/test2b-nginx-php/deployment-nginx-php.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: nginx-php-persistent
         lagoon.sh/template: nginx-php-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: NGINX_FASTCGI_PASS

--- a/internal/testdata/complex/service-templates/test2b-nginx-php/deployment-redis.yaml
+++ b/internal/testdata/complex/service-templates/test2b-nginx-php/deployment-redis.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: redis
         lagoon.sh/template: redis-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test2b-nginx-php/deployment-varnish.yaml
+++ b/internal/testdata/complex/service-templates/test2b-nginx-php/deployment-varnish.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: varnish
         lagoon.sh/template: varnish-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test2c-nginx-php/cronjob-cronjob-cli-drush-cron2.yaml
+++ b/internal/testdata/complex/service-templates/test2c-nginx-php/cronjob-cronjob-cli-drush-cron2.yaml
@@ -55,6 +55,7 @@ spec:
                   - key: lagoon.sh/spot
                     operator: Exists
                 weight: 1
+          automountServiceAccountToken: false
           containers:
           - command:
             - /lagoon/cronjob.sh

--- a/internal/testdata/complex/service-templates/test2c-nginx-php/deployment-cli.yaml
+++ b/internal/testdata/complex/service-templates/test2c-nginx-php/deployment-cli.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: cli-persistent
         lagoon.sh/template: cli-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test2c-nginx-php/deployment-nginx-php.yaml
+++ b/internal/testdata/complex/service-templates/test2c-nginx-php/deployment-nginx-php.yaml
@@ -54,6 +54,7 @@ spec:
               - key: lagoon.sh/spot
                 operator: Exists
             weight: 1
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: NGINX_FASTCGI_PASS

--- a/internal/testdata/complex/service-templates/test2c-nginx-php/deployment-redis.yaml
+++ b/internal/testdata/complex/service-templates/test2c-nginx-php/deployment-redis.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: redis
         lagoon.sh/template: redis-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test2c-nginx-php/deployment-varnish.yaml
+++ b/internal/testdata/complex/service-templates/test2c-nginx-php/deployment-varnish.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: varnish
         lagoon.sh/template: varnish-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test2d-nginx-php/cronjob-cronjob-cli-drush-cron2.yaml
+++ b/internal/testdata/complex/service-templates/test2d-nginx-php/cronjob-cronjob-cli-drush-cron2.yaml
@@ -45,6 +45,7 @@ spec:
             lagoon.sh/service-type: cli-persistent
             lagoon.sh/template: cli-persistent-0.1.0
         spec:
+          automountServiceAccountToken: false
           containers:
           - command:
             - /lagoon/cronjob.sh

--- a/internal/testdata/complex/service-templates/test2d-nginx-php/deployment-cli.yaml
+++ b/internal/testdata/complex/service-templates/test2d-nginx-php/deployment-cli.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: cli-persistent
         lagoon.sh/template: cli-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test2d-nginx-php/deployment-nginx-php.yaml
+++ b/internal/testdata/complex/service-templates/test2d-nginx-php/deployment-nginx-php.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: nginx-php-persistent
         lagoon.sh/template: nginx-php-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: NGINX_FASTCGI_PASS

--- a/internal/testdata/complex/service-templates/test2d-nginx-php/deployment-redis.yaml
+++ b/internal/testdata/complex/service-templates/test2d-nginx-php/deployment-redis.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: redis
         lagoon.sh/template: redis-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test2d-nginx-php/deployment-varnish.yaml
+++ b/internal/testdata/complex/service-templates/test2d-nginx-php/deployment-varnish.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: varnish
         lagoon.sh/template: varnish-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test8-multiple-services/deployment-mariadb-10-5.yaml
+++ b/internal/testdata/complex/service-templates/test8-multiple-services/deployment-mariadb-10-5.yaml
@@ -49,6 +49,7 @@ spec:
         lagoon.sh/service-type: mariadb-single
         lagoon.sh/template: mariadb-single-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test8-multiple-services/deployment-opensearch-2.yaml
+++ b/internal/testdata/complex/service-templates/test8-multiple-services/deployment-opensearch-2.yaml
@@ -48,6 +48,7 @@ spec:
         lagoon.sh/service-type: opensearch-persistent
         lagoon.sh/template: opensearch-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test8-multiple-services/deployment-postgres-11.yaml
+++ b/internal/testdata/complex/service-templates/test8-multiple-services/deployment-postgres-11.yaml
@@ -49,6 +49,7 @@ spec:
         lagoon.sh/service-type: postgres-single
         lagoon.sh/template: postgres-single-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test8-multiple-services/deployment-redis-6.yaml
+++ b/internal/testdata/complex/service-templates/test8-multiple-services/deployment-redis-6.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: redis
         lagoon.sh/template: redis-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test8-multiple-services/deployment-redis-7.yaml
+++ b/internal/testdata/complex/service-templates/test8-multiple-services/deployment-redis-7.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: redis
         lagoon.sh/template: redis-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test8-multiple-services/deployment-solr-8.yaml
+++ b/internal/testdata/complex/service-templates/test8-multiple-services/deployment-solr-8.yaml
@@ -48,6 +48,7 @@ spec:
         lagoon.sh/service-type: solr-php-persistent
         lagoon.sh/template: solr-php-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test8-multiple-services/deployment-web.yaml
+++ b/internal/testdata/complex/service-templates/test8-multiple-services/deployment-web.yaml
@@ -44,6 +44,7 @@ spec:
         lagoon.sh/service-type: basic-persistent
         lagoon.sh/template: basic-persistent-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test9-meta-dbaas-types/deployment-mariadb-10-11.yaml
+++ b/internal/testdata/complex/service-templates/test9-meta-dbaas-types/deployment-mariadb-10-11.yaml
@@ -49,6 +49,7 @@ spec:
         lagoon.sh/service-type: mariadb-single
         lagoon.sh/template: mariadb-single-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test9-meta-dbaas-types/deployment-mariadb-10-5.yaml
+++ b/internal/testdata/complex/service-templates/test9-meta-dbaas-types/deployment-mariadb-10-5.yaml
@@ -49,6 +49,7 @@ spec:
         lagoon.sh/service-type: mariadb-single
         lagoon.sh/template: mariadb-single-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test9-meta-dbaas-types/deployment-mongo-4.yaml
+++ b/internal/testdata/complex/service-templates/test9-meta-dbaas-types/deployment-mongo-4.yaml
@@ -48,6 +48,7 @@ spec:
         lagoon.sh/service-type: mongodb-single
         lagoon.sh/template: mongodb-single-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test9-meta-dbaas-types/deployment-postgres-11.yaml
+++ b/internal/testdata/complex/service-templates/test9-meta-dbaas-types/deployment-postgres-11.yaml
@@ -49,6 +49,7 @@ spec:
         lagoon.sh/service-type: postgres-single
         lagoon.sh/template: postgres-single-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA

--- a/internal/testdata/complex/service-templates/test9-meta-dbaas-types/deployment-postgres-15.yaml
+++ b/internal/testdata/complex/service-templates/test9-meta-dbaas-types/deployment-postgres-15.yaml
@@ -49,6 +49,7 @@ spec:
         lagoon.sh/service-type: postgres-single
         lagoon.sh/template: postgres-single-0.1.0
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LAGOON_GIT_SHA


### PR DESCRIPTION
This just makes sure that the serviceaccount token is not mounted into the running pod. No services should be using this, and it doesn't provide any benefits.

closes #419 