### PR TITLE
fix: use compose spec with servicename validity check for labels

### DIFF
--- a/internal/testdata/basic/docker-compose.yml
+++ b/internal/testdata/basic/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       context: internal/testdata/basic/docker
       dockerfile: basic.dockerfile
     labels:
-      lagoon.type: basic
-      lagoon.service.usecomposeports: true
+      - "lagoon.type=basic"
+      - "lagoon.service.usecomposeports=true"
     volumes:
       - .:/app:delegated
     ports:


### PR DESCRIPTION
Passes in the compose service definition to verify the labels used now instead of checking yaml directly.

Adjusted one of the test case docker compose files to use the list for labels to ensure that the tests pass correctly for this other label format.