### PR TITLE
fix: use secretKeyRef in prebackuppods

### DIFF
--- a/internal/templating/template_prebackuppod.go
+++ b/internal/templating/template_prebackuppod.go
@@ -122,7 +122,7 @@ func GeneratePreBackupPod(
 					prebackuppod.Spec.Pod.Spec.Containers[0].Env = append(prebackuppod.Spec.Pod.Spec.Containers[0].Env, v1.EnvVar{
 						Name: "BACKUP_DB_READREPLICA_HOSTS",
 						ValueFrom: &v1.EnvVarSource{
-							ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+							SecretKeyRef: &v1.SecretKeySelector{
 								Key: fmt.Sprintf("%s_READREPLICA_HOSTS", varFix(serviceValues.OverrideName)),
 								LocalObjectReference: v1.LocalObjectReference{
 									Name: "lagoon-env",
@@ -212,7 +212,7 @@ func GeneratePreBackupPod(
 					prebackuppod.Spec.Pod.Spec.Containers[0].Env = append(prebackuppod.Spec.Pod.Spec.Containers[0].Env, v1.EnvVar{
 						Name: "BACKUP_DB_READREPLICA_HOSTS",
 						ValueFrom: &v1.EnvVarSource{
-							ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+							SecretKeyRef: &v1.SecretKeySelector{
 								Key: fmt.Sprintf("%s_READREPLICA_HOSTS", varFix(serviceValues.OverrideName)),
 								LocalObjectReference: v1.LocalObjectReference{
 									Name: "lagoon-env",
@@ -337,22 +337,22 @@ pod:
       env:
       - name: BACKUP_DB_HOST
         valueFrom:
-          configMapKeyRef:
+          secretKeyRef:
             key: {{ .Service.Name | VarFix }}_HOST
             name: lagoon-env
       - name: BACKUP_DB_USERNAME
         valueFrom:
-          configMapKeyRef:
+          secretKeyRef:
             key: {{ .Service.Name | VarFix }}_USERNAME
             name: lagoon-env
       - name: BACKUP_DB_PASSWORD
         valueFrom:
-          configMapKeyRef:
+          secretKeyRef:
             key: {{ .Service.Name | VarFix }}_PASSWORD
             name: lagoon-env
       - name: BACKUP_DB_DATABASE
         valueFrom:
-          configMapKeyRef:
+          secretKeyRef:
             key: {{ .Service.Name | VarFix }}_DATABASE
             name: lagoon-env
       image: uselagoon/database-tools:latest
@@ -377,22 +377,22 @@ pod:
       env:
       - name: BACKUP_DB_HOST
         valueFrom:
-          configMapKeyRef:
+          secretKeyRef:
             key: {{ .Service.Name | VarFix }}_HOST
             name: lagoon-env
       - name: BACKUP_DB_USERNAME
         valueFrom:
-          configMapKeyRef:
+          secretKeyRef:
             key: {{ .Service.Name | VarFix }}_USERNAME
             name: lagoon-env
       - name: BACKUP_DB_PASSWORD
         valueFrom:
-          configMapKeyRef:
+          secretKeyRef:
             key: {{ .Service.Name | VarFix }}_PASSWORD
             name: lagoon-env
       - name: BACKUP_DB_DATABASE
         valueFrom:
-          configMapKeyRef:
+          secretKeyRef:
             key: {{ .Service.Name | VarFix }}_DATABASE
             name: lagoon-env
       image: uselagoon/database-tools:latest
@@ -409,42 +409,42 @@ pod:
       env:
       - name: BACKUP_DB_HOST
         valueFrom:
-          configMapKeyRef:
+          secretKeyRef:
             key: {{ .Service.Name | VarFix }}_HOST
             name: lagoon-env
       - name: BACKUP_DB_USERNAME
         valueFrom:
-          configMapKeyRef:
+          secretKeyRef:
             key: {{ .Service.Name | VarFix }}_USERNAME
             name: lagoon-env
       - name: BACKUP_DB_PASSWORD
         valueFrom:
-          configMapKeyRef:
+          secretKeyRef:
             key: {{ .Service.Name | VarFix }}_PASSWORD
             name: lagoon-env
       - name: BACKUP_DB_DATABASE
         valueFrom:
-          configMapKeyRef:
+          secretKeyRef:
             key: {{ .Service.Name | VarFix }}_DATABASE
             name: lagoon-env
       - name: BACKUP_DB_PORT
         valueFrom:
-          configMapKeyRef:
+          secretKeyRef:
             key: {{ .Service.Name | VarFix }}_PORT
             name: lagoon-env
       - name: BACKUP_DB_AUTHSOURCE
         valueFrom:
-          configMapKeyRef:
+          secretKeyRef:
             key: {{ .Service.Name | VarFix }}_AUTHSOURCE
             name: lagoon-env
       - name: BACKUP_DB_AUTHMECHANISM
         valueFrom:
-          configMapKeyRef:
+          secretKeyRef:
             key: {{ .Service.Name | VarFix }}_AUTHMECHANISM
             name: lagoon-env
       - name: BACKUP_DB_AUTHTLS
         valueFrom:
-          configMapKeyRef:
+          secretKeyRef:
             key: {{ .Service.Name | VarFix }}_AUTHTLS
             name: lagoon-env
       image: uselagoon/database-tools:latest

--- a/internal/templating/test-resources/backups/result-prebackuppod1.yaml
+++ b/internal/templating/test-resources/backups/result-prebackuppod1.yaml
@@ -32,27 +32,27 @@ spec:
         env:
         - name: BACKUP_DB_HOST
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_DATABASE_HOST
               name: lagoon-env
         - name: BACKUP_DB_USERNAME
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_DATABASE_USERNAME
               name: lagoon-env
         - name: BACKUP_DB_PASSWORD
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_DATABASE_PASSWORD
               name: lagoon-env
         - name: BACKUP_DB_DATABASE
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_DATABASE_DATABASE
               name: lagoon-env
         - name: BACKUP_DB_READREPLICA_HOSTS
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_DATABASE_READREPLICA_HOSTS
               name: lagoon-env
         image: uselagoon/database-tools:latest

--- a/internal/templating/test-resources/backups/result-prebackuppod2.yaml
+++ b/internal/templating/test-resources/backups/result-prebackuppod2.yaml
@@ -32,27 +32,27 @@ spec:
         env:
         - name: BACKUP_DB_HOST
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: POSTGRES_DATABASE_HOST
               name: lagoon-env
         - name: BACKUP_DB_USERNAME
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: POSTGRES_DATABASE_USERNAME
               name: lagoon-env
         - name: BACKUP_DB_PASSWORD
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: POSTGRES_DATABASE_PASSWORD
               name: lagoon-env
         - name: BACKUP_DB_DATABASE
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: POSTGRES_DATABASE_DATABASE
               name: lagoon-env
         - name: BACKUP_DB_READREPLICA_HOSTS
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: POSTGRES_DATABASE_READREPLICA_HOSTS
               name: lagoon-env
         image: uselagoon/database-tools:latest

--- a/internal/templating/test-resources/backups/result-prebackuppod3.yaml
+++ b/internal/templating/test-resources/backups/result-prebackuppod3.yaml
@@ -34,47 +34,47 @@ spec:
         env:
         - name: BACKUP_DB_HOST
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MONGODB_DATABASE_HOST
               name: lagoon-env
         - name: BACKUP_DB_USERNAME
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MONGODB_DATABASE_USERNAME
               name: lagoon-env
         - name: BACKUP_DB_PASSWORD
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MONGODB_DATABASE_PASSWORD
               name: lagoon-env
         - name: BACKUP_DB_DATABASE
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MONGODB_DATABASE_DATABASE
               name: lagoon-env
         - name: BACKUP_DB_PORT
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MONGODB_DATABASE_PORT
               name: lagoon-env
         - name: BACKUP_DB_AUTHSOURCE
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MONGODB_DATABASE_AUTHSOURCE
               name: lagoon-env
         - name: BACKUP_DB_AUTHMECHANISM
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MONGODB_DATABASE_AUTHMECHANISM
               name: lagoon-env
         - name: BACKUP_DB_AUTHTLS
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MONGODB_DATABASE_AUTHTLS
               name: lagoon-env
         - name: BACKUP_DB_READREPLICA_HOSTS
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MONGODB_DATABASE_READREPLICA_HOSTS
               name: lagoon-env
         image: uselagoon/database-tools:latest

--- a/internal/templating/test-resources/backups/result-prebackuppod4.yaml
+++ b/internal/templating/test-resources/backups/result-prebackuppod4.yaml
@@ -32,27 +32,27 @@ spec:
         env:
         - name: BACKUP_DB_HOST
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_DATABASE_HOST
               name: lagoon-env
         - name: BACKUP_DB_USERNAME
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_DATABASE_USERNAME
               name: lagoon-env
         - name: BACKUP_DB_PASSWORD
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_DATABASE_PASSWORD
               name: lagoon-env
         - name: BACKUP_DB_DATABASE
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_DATABASE_DATABASE
               name: lagoon-env
         - name: BACKUP_DB_READREPLICA_HOSTS
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_DATABASE_READREPLICA_HOSTS
               name: lagoon-env
         image: uselagoon/database-tools:latest

--- a/internal/templating/test-resources/backups/result-prebackuppod5.yaml
+++ b/internal/templating/test-resources/backups/result-prebackuppod5.yaml
@@ -32,27 +32,27 @@ spec:
         env:
         - name: BACKUP_DB_HOST
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_DATABASE_HOST
               name: lagoon-env
         - name: BACKUP_DB_USERNAME
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_DATABASE_USERNAME
               name: lagoon-env
         - name: BACKUP_DB_PASSWORD
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_DATABASE_PASSWORD
               name: lagoon-env
         - name: BACKUP_DB_DATABASE
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_DATABASE_DATABASE
               name: lagoon-env
         - name: BACKUP_DB_READREPLICA_HOSTS
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_DATABASE_READREPLICA_HOSTS
               name: lagoon-env
         image: uselagoon/database-tools:latest
@@ -93,27 +93,27 @@ spec:
         env:
         - name: BACKUP_DB_HOST
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_HOST
               name: lagoon-env
         - name: BACKUP_DB_USERNAME
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_USERNAME
               name: lagoon-env
         - name: BACKUP_DB_PASSWORD
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_PASSWORD
               name: lagoon-env
         - name: BACKUP_DB_DATABASE
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_DATABASE
               name: lagoon-env
         - name: BACKUP_DB_READREPLICA_HOSTS
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_READREPLICA_HOSTS
               name: lagoon-env
         image: uselagoon/database-tools:latest

--- a/internal/testdata/complex/backup-templates/backup-1/prebackuppods.yaml
+++ b/internal/testdata/complex/backup-templates/backup-1/prebackuppods.yaml
@@ -32,22 +32,22 @@ spec:
         env:
         - name: BACKUP_DB_HOST
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_HOST
               name: lagoon-env
         - name: BACKUP_DB_USERNAME
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_USERNAME
               name: lagoon-env
         - name: BACKUP_DB_PASSWORD
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_PASSWORD
               name: lagoon-env
         - name: BACKUP_DB_DATABASE
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_DATABASE
               name: lagoon-env
         image: imagecache.example.com/uselagoon/database-tools:latest

--- a/internal/testdata/complex/backup-templates/backup-2/prebackuppods.yaml
+++ b/internal/testdata/complex/backup-templates/backup-2/prebackuppods.yaml
@@ -32,22 +32,22 @@ spec:
         env:
         - name: BACKUP_DB_HOST
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_HOST
               name: lagoon-env
         - name: BACKUP_DB_USERNAME
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_USERNAME
               name: lagoon-env
         - name: BACKUP_DB_PASSWORD
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_PASSWORD
               name: lagoon-env
         - name: BACKUP_DB_DATABASE
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: MARIADB_DATABASE
               name: lagoon-env
         image: imagecache.example.com/uselagoon/database-tools:latest


### PR DESCRIPTION
In #397 we changed the `lagoon-env` configmap to secret. This fixes a missing change to prebackuppods that also sets this.