### PR TITLE
Feature: Adds environment type to insights config maps

### DIFF
--- a/legacy/scripts/exec-generate-insights-configmap.sh
+++ b/legacy/scripts/exec-generate-insights-configmap.sh
@@ -45,6 +45,7 @@ processImageInspect() {
       lagoon.sh/project=${PROJECT} \
       lagoon.sh/environment=${ENVIRONMENT} \
       lagoon.sh/service=${IMAGE_NAME} \
+      lagoon.sh/environmentType=${ENVIRONMENT_TYPE} \
       insights.lagoon.sh/type=inspect
 }
 
@@ -90,6 +91,7 @@ processSbom() {
         lagoon.sh/project=${PROJECT} \
         lagoon.sh/environment=${ENVIRONMENT} \
         lagoon.sh/service=${IMAGE_NAME} \
+        lagoon.sh/environmentType=${ENVIRONMENT_TYPE} \
         insights.lagoon.sh/type=sbom
   fi
 }


### PR DESCRIPTION
Extends insights labels to include the environment type (development/production) in the insights config maps.
