### PR TITLE
refactor: disable automount with admin flag override

### DIFF
--- a/internal/generator/buildvalues.go
+++ b/internal/generator/buildvalues.go
@@ -89,7 +89,8 @@ type BuildValues struct {
 	ConfigSSHHost                 string                       `json:"configSSHHost"`
 	ConfigSSHPort                 string                       `json:"configSSHPort"`
 	LagoonEnvVariables            map[string]string            `json:"lagoonEnvVariables" description:"map of variables that will be saved into the lagoon-env secret"`
-	LagoonPlatformEnvVariables    map[string]string            `json:"agoonPlatformEnvVariables" description:"map of variables that will be saved into the lagoon-platform-env secret"`
+	LagoonPlatformEnvVariables    map[string]string            `json:"lagoonPlatformEnvVariables" description:"map of variables that will be saved into the lagoon-platform-env secret"`
+	AutoMountServiceAccountToken  bool                         `json:"autoMountServiceAccountToken" description:"flag to enable automounting the service account token"`
 }
 
 type Resources struct {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -352,6 +352,8 @@ func NewGenerator(
 	buildValues.Resources.Limits.Memory = CheckAdminFeatureFlag("CONTAINER_MEMORY_LIMIT", false)
 	buildValues.Resources.Limits.EphemeralStorage = CheckAdminFeatureFlag("EPHEMERAL_STORAGE_LIMIT", false)
 	buildValues.Resources.Requests.EphemeralStorage = CheckAdminFeatureFlag("EPHEMERAL_STORAGE_REQUESTS", false)
+	automount, _ := strconv.ParseBool(CheckAdminFeatureFlag("AUTOMOUNT_SERVICE_ACCOUNT_TOKEN", false))
+	buildValues.AutoMountServiceAccountToken = automount
 	// validate that what is provided
 	if buildValues.Resources.Limits.Memory != "" {
 		err := ValidateResourceQuantity(buildValues.Resources.Limits.Memory)

--- a/internal/templating/templates_cronjob.go
+++ b/internal/templating/templates_cronjob.go
@@ -101,7 +101,7 @@ func GenerateCronjobTemplate(
 				}
 
 				// disable automounted service account
-				cronjob.Spec.JobTemplate.Spec.Template.Spec.AutomountServiceAccountToken = helpers.BoolPtr(false)
+				cronjob.Spec.JobTemplate.Spec.Template.Spec.AutomountServiceAccountToken = &buildValues.AutoMountServiceAccountToken
 
 				cronjob.Spec.Schedule = nCronjob.Schedule
 				cronjob.Spec.ConcurrencyPolicy = batchv1.ForbidConcurrent

--- a/internal/templating/templates_deployment.go
+++ b/internal/templating/templates_deployment.go
@@ -102,7 +102,7 @@ func GenerateDeploymentTemplate(
 			deployment.ObjectMeta.Annotations = annotations
 
 			// disable automounted service account
-			deployment.Spec.Template.Spec.AutomountServiceAccountToken = helpers.BoolPtr(false)
+			deployment.Spec.Template.Spec.AutomountServiceAccountToken = &buildValues.AutoMountServiceAccountToken
 
 			if serviceValues.UseSpotInstances {
 				// handle spot instance label and affinity/tolerations/selectors


### PR DESCRIPTION
Refactor the automount service account token to allow for administratively enabling it via lagoon-remote only.

It is still disabled by default, and only the `ADMIN_LAGOON_FEATURE_FLAG_AUTOMOUNT_SERVICE_ACCOUNT_TOKEN=true` variable being added to the `lagoon-remote` or remote-controller will be able to enable this functionality.