### PR TITLE
chore: add retry message to dockerhost connection failure

### DIFF
--- a/legacy/docker-entrypoint.sh
+++ b/legacy/docker-entrypoint.sh
@@ -11,7 +11,9 @@ if [ $DOCKER_HOST_COUNTER -lt $DOCKER_HOST_TIMEOUT ]; then
     echo "${DOCKER_HOST} not available yet, waiting for 5 secs"
     sleep 5
 else
-    echo "could not connect to ${DOCKER_HOST}"
+    echo "Error: could not connect to ${DOCKER_HOST}"
+    echo "Please trigger another deployment."
+    echo "If the error persists please contact support."
     exit 1
 fi
 done


### PR DESCRIPTION
In the event that the dockerhost fails to connect and a build fails, instruct the user to retry. If it continues, contact support.

Usually this has been shows as a result of an intermittent network issue, but if it is persistent then there could be a problem with the docker-host that needs to be investigated by a platform operator.