### PR TITLE
feat: enable persistent storage in redis 8+ Lagoon images

### DIFF
--- a/internal/servicetypes/redis.go
+++ b/internal/servicetypes/redis.go
@@ -79,6 +79,12 @@ var redisPersistent = ServiceType{
 	PrimaryContainer: ServiceContainer{
 		Name:      redis.PrimaryContainer.Name,
 		Container: redis.PrimaryContainer.Container,
+		EnvVars: []corev1.EnvVar{
+			{
+				Name:  "REDIS_FLAVOR",
+				Value: "persistent",
+			},
+		},
 	},
 	Volumes: ServiceVolume{
 		PersistentVolumeSize: "5Gi",

--- a/internal/templating/test-resources/deployment/result-redis-1.yaml
+++ b/internal/templating/test-resources/deployment/result-redis-1.yaml
@@ -142,6 +142,8 @@ spec:
       automountServiceAccountToken: false
       containers:
       - env:
+        - name: REDIS_FLAVOR
+          value: persistent
         - name: LAGOON_GIT_SHA
           value: "0"
         - name: CRONJOBS

--- a/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-redis-persist.yaml
+++ b/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-redis-persist.yaml
@@ -51,6 +51,8 @@ spec:
       automountServiceAccountToken: false
       containers:
       - env:
+        - name: REDIS_FLAVOR
+          value: persistent
         - name: LAGOON_GIT_SHA
           value: "0000000000000000000000000000000000000000"
         - name: CRONJOBS

--- a/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-redis-session.yaml
+++ b/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-redis-session.yaml
@@ -51,6 +51,8 @@ spec:
       automountServiceAccountToken: false
       containers:
       - env:
+        - name: REDIS_FLAVOR
+          value: persistent
         - name: LAGOON_GIT_SHA
           value: "0000000000000000000000000000000000000000"
         - name: CRONJOBS

--- a/internal/testdata/complex/service-templates/test-redis-persistent-k8upv2/deployment-redis.yaml
+++ b/internal/testdata/complex/service-templates/test-redis-persistent-k8upv2/deployment-redis.yaml
@@ -50,6 +50,8 @@ spec:
       automountServiceAccountToken: false
       containers:
       - env:
+        - name: REDIS_FLAVOR
+          value: persistent
         - name: LAGOON_GIT_SHA
           value: abcdefg123456
         - name: CRONJOBS


### PR DESCRIPTION
Starting in uselagoon/redis-8, there is no longer a separate persistent image, and an env var needs to be added to enable peristent storage.

https://github.com/uselagoon/lagoon-images/pull/1296