### PR TITLE
feat: add support for external service type

### DIFF
--- a/cmd/template_lagoonservices.go
+++ b/cmd/template_lagoonservices.go
@@ -145,6 +145,20 @@ func LagoonServiceTemplateGeneration(g generator.GeneratorInput) error {
 		}
 		helpers.WriteTemplateFile(fmt.Sprintf("%s/isolation-network-policy.yaml", savedTemplates), templateBytes)
 	}
+	serviceNetPols, err := servicestemplates.GenerateServiceNetworkPolicies(*lagoonBuild.BuildValues)
+	if err != nil {
+		return fmt.Errorf("couldn't generate template: %v", err)
+	}
+	for _, serviceNetPol := range serviceNetPols {
+		templateBytes, err := servicestemplates.TemplateNetworkPolicy(&serviceNetPol)
+		if err != nil {
+			return fmt.Errorf("couldn't generate template: %v", err)
+		}
+		if g.Debug {
+			fmt.Printf("Templating networkpolicy manifests %s\n", fmt.Sprintf("%s/networkpolicy-%s.yaml", savedTemplates, serviceNetPol.Name))
+		}
+		helpers.WriteTemplateFile(fmt.Sprintf("%s/networkpolicy-%s.yaml", savedTemplates, serviceNetPol.Name), templateBytes)
+	}
 	return nil
 }
 

--- a/cmd/template_lagoonservices_test.go
+++ b/cmd/template_lagoonservices_test.go
@@ -627,6 +627,38 @@ func TestTemplateLagoonServices(t *testing.T) {
 			templatePath: "testoutput",
 			want:         "internal/testdata/basic/service-templates/test-basic-single-k8upv2",
 		},
+		{
+			name:        "test-basic-external-service",
+			description: "tests a basic deployment with a basic and an external service and network policy to share a service",
+			args: testdata.GetSeedData(
+				testdata.TestData{
+					ProjectName:     "example-project",
+					EnvironmentName: "main",
+					Branch:          "main",
+					LagoonYAML:      "internal/testdata/basic/lagoon.externalservice.yml",
+					ImageReferences: map[string]string{
+						"basic1": "harbor.example/example-project/main/basic1@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8",
+					},
+				}, true),
+			templatePath: "testoutput",
+			want:         "internal/testdata/basic/service-templates/test-basic-external-service",
+		},
+		{
+			name:        "test-basic-external-service-environment",
+			description: "tests a basic deployment with a basic and an external service and network policy to share when defined under the environment",
+			args: testdata.GetSeedData(
+				testdata.TestData{
+					ProjectName:     "example-project",
+					EnvironmentName: "stage",
+					Branch:          "stage",
+					LagoonYAML:      "internal/testdata/basic/lagoon.externalservice.yml",
+					ImageReferences: map[string]string{
+						"basic1": "harbor.example/example-project/stage/basic1@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8",
+					},
+				}, true),
+			templatePath: "testoutput",
+			want:         "internal/testdata/basic/service-templates/test-basic-external-service-environment",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -37,6 +37,7 @@ type LagoonEnvState struct {
 	MariaDBConsumers      *mariadbv1.MariaDBConsumerList     `json:"mariadbconsumers"`
 	MongoDBConsumers      *mongodbv1.MongoDBConsumerList     `json:"mongodbconsumers"`
 	PostgreSQLConsumers   *postgresv1.PostgreSQLConsumerList `json:"postgresqlconsumers"`
+	NetworkPolicies       *networkv1.NetworkPolicyList       `json:"networkpolicies"`
 }
 
 func NewCollector(client client.Client) *Collector {
@@ -127,6 +128,10 @@ func (c *Collector) Collect(ctx context.Context, namespace string) (*LagoonEnvSt
 			fmt.Fprintln(os.Stderr, err)
 			return nil, err
 		}
+	}
+	state.NetworkPolicies, err = c.CollectNetworkPolicies(ctx, namespace)
+	if err != nil {
+		return nil, err
 	}
 	return &state, nil
 }

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -32,7 +32,7 @@ func TestCollector_Collect(t *testing.T) {
 				namespace: "example-project-main",
 			},
 			seedDir: "testdata/seed/seed-1",
-			want:    "testdata/result/result-1/",
+			want:    "testdata/result/result-1",
 			wantErr: false,
 		},
 		{
@@ -42,7 +42,17 @@ func TestCollector_Collect(t *testing.T) {
 				namespace: "example-project-main",
 			},
 			seedDir: "testdata/seed/seed-2",
-			want:    "testdata/result/result-2/",
+			want:    "testdata/result/result-2",
+			wantErr: false,
+		},
+		{
+			name: "list-environment-netpol",
+			args: args{
+				ctx:       context.Background(),
+				namespace: "example-project-main",
+			},
+			seedDir: "testdata/seed/seed-3",
+			want:    "testdata/result/result-3",
 			wantErr: false,
 		},
 	}
@@ -64,84 +74,65 @@ func TestCollector_Collect(t *testing.T) {
 				t.Errorf("Collector.Collect() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			results, err := os.ReadDir(tt.want)
-			if err != nil {
-				t.Errorf("couldn't read directory %v: %v", tt.want, err)
+			if len(got.Deployments.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-deployments.yaml"), got.Deployments)
 			}
-			for _, r := range results {
-				var rBytes []byte
-				switch r.Name() {
-				case "lagoon-deployments.yaml":
-					rBytes, err = yaml.Marshal(got.Deployments)
-					if err != nil {
-						t.Errorf("couldn't marshal deployments: %v", err)
-					}
-				case "lagoon-cronjobs.yaml":
-					rBytes, err = yaml.Marshal(got.Cronjobs)
-					if err != nil {
-						t.Errorf("couldn't marshal cronjobs: %v", err)
-					}
-				case "lagoon-ingress.yaml":
-					rBytes, err = yaml.Marshal(got.Ingress)
-					if err != nil {
-						t.Errorf("couldn't marshal ingress: %v", err)
-					}
-				case "lagoon-services.yaml":
-					rBytes, err = yaml.Marshal(got.Services)
-					if err != nil {
-						t.Errorf("couldn't marshal services: %v", err)
-					}
-				case "lagoon-secrets.yaml":
-					rBytes, err = yaml.Marshal(got.Secrets)
-					if err != nil {
-						t.Errorf("couldn't marshal secrets: %v", err)
-					}
-				case "lagoon-mariadb-consumers.yaml":
-					rBytes, err = yaml.Marshal(got.MariaDBConsumers)
-					if err != nil {
-						t.Errorf("couldn't marshal mariadb-consumers: %v", err)
-					}
-				case "lagoon-mongodb-consumers.yaml":
-					rBytes, err = yaml.Marshal(got.MongoDBConsumers)
-					if err != nil {
-						t.Errorf("couldn't marshal mongodb-consumers: %v", err)
-					}
-				case "lagoon-postgres-consumers.yaml":
-					rBytes, err = yaml.Marshal(got.PostgreSQLConsumers)
-					if err != nil {
-						t.Errorf("couldn't marshal postgres-consumers: %v", err)
-					}
-				case "lagoon-schedules-v1.yaml":
-					rBytes, err = yaml.Marshal(got.SchedulesV1)
-					if err != nil {
-						t.Errorf("couldn't marshal schedules-v1: %v", err)
-					}
-				case "lagoon-schedules-v1alpha1.yaml":
-					rBytes, err = yaml.Marshal(got.SchedulesV1Alpha1)
-					if err != nil {
-						t.Errorf("couldn't marshal schedules-v1alpha1: %v", err)
-					}
-				case "lagoon-prebackuppods-v1.yaml":
-					rBytes, err = yaml.Marshal(got.PreBackupPodsV1)
-					if err != nil {
-						t.Errorf("couldn't marshal prebackuppods-v1: %v", err)
-					}
-				case "lagoon-prebackuppods-v1alpha1.yaml":
-					rBytes, err = yaml.Marshal(got.PreBackupPodsV1Alpha1)
-					if err != nil {
-						t.Errorf("couldn't marshal prebackuppods-v1alpha1: %v", err)
-					}
-				default:
-					continue
-				}
-				r1, err := os.ReadFile(fmt.Sprintf("%s/%s", tt.want, r.Name()))
-				if err != nil {
-					t.Errorf("couldn't read file %v: %v", fmt.Sprintf("%s/%s", tt.want, r.Name()), err)
-				}
-				if !reflect.DeepEqual(rBytes, r1) {
-					t.Errorf("Collect() = \n%v", diff.LineDiff(string(r1), string(rBytes)))
-				}
+			if len(got.Cronjobs.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-cronjobs.yaml"), got.Cronjobs)
+			}
+			if len(got.Ingress.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-ingress.yaml"), got.Ingress)
+			}
+			if len(got.Services.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-services.yaml"), got.Services)
+			}
+			if len(got.Secrets.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-secrets.yaml"), got.Secrets)
+			}
+			if len(got.MariaDBConsumers.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-mariadb-consumers.yaml"), got.MariaDBConsumers)
+			}
+			if len(got.MongoDBConsumers.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-mongodb-consumers.yaml"), got.MongoDBConsumers)
+			}
+			if len(got.PostgreSQLConsumers.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-postgres-consumers.yaml"), got.PostgreSQLConsumers)
+			}
+			if len(got.SchedulesV1.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-schedules-v1.yaml"), got.SchedulesV1)
+			}
+			if len(got.SchedulesV1Alpha1.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-schedules-v1alpha1.yaml"), got.SchedulesV1Alpha1)
+			}
+			if len(got.PreBackupPodsV1.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-prebackuppods-v1.yaml"), got.PreBackupPodsV1)
+			}
+			if len(got.PreBackupPodsV1Alpha1.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-prebackuppods-v1alpha1.yaml"), got.PreBackupPodsV1Alpha1)
+			}
+			if len(got.NetworkPolicies.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-networkpolicies.yaml"), got.NetworkPolicies)
 			}
 		})
+	}
+}
+
+func checkResult(t *testing.T, want string, got interface{}) {
+	rBytes, err := yaml.Marshal(got)
+	if err != nil {
+		t.Errorf("couldn't marshal deployments: %v", err)
+	}
+	r1, err := os.ReadFile(want)
+	if err != nil {
+		// try create the file if it doesn't exist
+		err := os.WriteFile(want, rBytes, 0644)
+		if err != nil {
+			t.Errorf("couldn't write file %v: %v", want, err)
+		} else {
+			t.Errorf("couldn't read file %v: %v", want, err)
+		}
+	}
+	if !reflect.DeepEqual(rBytes, r1) {
+		t.Errorf("Collect() = \n%v", diff.LineDiff(string(r1), string(rBytes)))
 	}
 }

--- a/internal/collector/networkpolicies.go
+++ b/internal/collector/networkpolicies.go
@@ -1,0 +1,26 @@
+package collector
+
+import (
+	"context"
+
+	networkv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (c *Collector) CollectNetworkPolicies(ctx context.Context, namespace string) (*networkv1.NetworkPolicyList, error) {
+	labelRequirements1, _ := labels.NewRequirement("lagoon.sh/service", selection.Exists, nil)
+	listOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
+		client.InNamespace(namespace),
+		client.MatchingLabelsSelector{
+			Selector: labels.NewSelector().Add(*labelRequirements1),
+		},
+	})
+	list := &networkv1.NetworkPolicyList{}
+	err := c.Client.List(ctx, list, listOption)
+	if err != nil {
+		return nil, err
+	}
+	return list, nil
+}

--- a/internal/collector/networkpolicies_test.go
+++ b/internal/collector/networkpolicies_test.go
@@ -1,0 +1,80 @@
+package collector
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/andreyvit/diff"
+	"github.com/uselagoon/build-deploy-tool/internal/k8s"
+	"sigs.k8s.io/yaml"
+)
+
+func TestCollector_CollectNetworkPolicies(t *testing.T) {
+	type args struct {
+		ctx       context.Context
+		namespace string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		seedDir string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "new-environment",
+			args: args{
+				ctx:       context.Background(),
+				namespace: "example-project-main",
+			},
+			seedDir: "testdata/seed/seed-empty",
+			want:    "testdata/result/result-empty/lagoon-networkpolicies.yaml",
+			wantErr: false,
+		},
+		{
+			name: "list-services",
+			args: args{
+				ctx:       context.Background(),
+				namespace: "example-project-main",
+			},
+			seedDir: "testdata/seed/seed-1",
+			want:    "testdata/result/result-1/lagoon-networkpolicies.yaml",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := k8s.NewFakeClient(tt.args.namespace)
+			if err != nil {
+				t.Errorf("error creating fake client")
+			}
+			err = k8s.SeedFakeData(client, tt.args.namespace, tt.seedDir)
+			if err != nil {
+				t.Errorf("error seeding fake data: %v", err)
+			}
+			c := &Collector{
+				Client: client,
+			}
+			got, err := c.CollectNetworkPolicies(tt.args.ctx, tt.args.namespace)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Collector.CollectNetworkPolicies() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			oJ, _ := yaml.Marshal(got)
+			results, err := os.ReadFile(tt.want)
+			if err != nil {
+				// try create the file if it doesn't exist
+				err := os.WriteFile(tt.want, oJ, 0644)
+				if err != nil {
+					t.Errorf("couldn't write file %v: %v", tt.want, err)
+				} else {
+					t.Errorf("couldn't read file %v: %v", tt.want, err)
+				}
+			}
+			if string(oJ) != string(results) {
+				t.Errorf("Collector.CollectNetworkPolicies() = \n%v", diff.LineDiff(string(results), string(oJ)))
+			}
+		})
+	}
+}

--- a/internal/collector/testdata/json-result/result-1.json
+++ b/internal/collector/testdata/json-result/result-1.json
@@ -721,5 +721,9 @@
   "postgresqlconsumers": {
     "metadata": {},
     "items": []
+  },
+  "networkpolicies": {
+    "metadata": {},
+    "items": []
   }
 }

--- a/internal/collector/testdata/json-result/result-2.json
+++ b/internal/collector/testdata/json-result/result-2.json
@@ -436,5 +436,9 @@
   "postgresqlconsumers": {
     "metadata": {},
     "items": []
+  },
+  "networkpolicies": {
+    "metadata": {},
+    "items": []
   }
 }

--- a/internal/collector/testdata/result/result-1/lagoon-networkpolicies.yaml
+++ b/internal/collector/testdata/result/result-1/lagoon-networkpolicies.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-2/lagoon-networkpolicies.yaml
+++ b/internal/collector/testdata/result/result-2/lagoon-networkpolicies.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-cronjobs.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-cronjobs.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-deployments.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-deployments.yaml
@@ -1,0 +1,89 @@
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      lagoon.sh/branch: main
+      lagoon.sh/version: v2.7.x
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/instance: basic1
+      app.kubernetes.io/managed-by: build-deploy-tool
+      app.kubernetes.io/name: basic
+      lagoon.sh/buildType: branch
+      lagoon.sh/environment: main
+      lagoon.sh/environmentType: production
+      lagoon.sh/project: example-project
+      lagoon.sh/service: basic1
+      lagoon.sh/service-type: basic
+      lagoon.sh/template: basic-0.1.0
+    name: basic1
+    namespace: example-project-main
+    resourceVersion: "1"
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/instance: basic1
+        app.kubernetes.io/name: basic
+    strategy: {}
+    template:
+      metadata:
+        annotations:
+          lagoon.sh/branch: main
+          lagoon.sh/configMapSha: abcdefg1234567890
+          lagoon.sh/version: v2.7.x
+        creationTimestamp: null
+        labels:
+          app.kubernetes.io/instance: basic1
+          app.kubernetes.io/managed-by: build-deploy-tool
+          app.kubernetes.io/name: basic
+          lagoon.sh/buildType: branch
+          lagoon.sh/environment: main
+          lagoon.sh/environmentType: production
+          lagoon.sh/project: example-project
+          lagoon.sh/service: basic1
+          lagoon.sh/service-type: basic
+          lagoon.sh/template: basic-0.1.0
+      spec:
+        automountServiceAccountToken: false
+        containers:
+        - env:
+          - name: LAGOON_GIT_SHA
+            value: abcdefg123456
+          - name: CRONJOBS
+          - name: SERVICE_NAME
+            value: basic1
+          envFrom:
+          - secretRef:
+              name: lagoon-platform-env
+          - secretRef:
+              name: lagoon-env
+          image: harbor.example/example-project/main/basic1@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8
+          imagePullPolicy: Always
+          livenessProbe:
+            initialDelaySeconds: 60
+            tcpSocket:
+              port: 8080
+            timeoutSeconds: 10
+          name: basic
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          readinessProbe:
+            initialDelaySeconds: 1
+            tcpSocket:
+              port: 8080
+            timeoutSeconds: 1
+          resources:
+            requests:
+              cpu: 10m
+              memory: 10Mi
+          securityContext: {}
+        enableServiceLinks: false
+        imagePullSecrets:
+        - name: lagoon-internal-registry-secret
+        priorityClassName: lagoon-priority-production
+  status: {}
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-ingress.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-ingress.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-mariadb-consumers.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-mariadb-consumers.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-mongodb-consumers.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-mongodb-consumers.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-networkpolicies.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-networkpolicies.yaml
@@ -1,0 +1,85 @@
+items:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    annotations:
+      lagoon.sh/branch: main
+      lagoon.sh/version: v2.7.x
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/instance: service-network-policy
+      app.kubernetes.io/managed-by: build-deploy-tool
+      app.kubernetes.io/name: service-network-policy
+      lagoon.sh/buildType: branch
+      lagoon.sh/environment: main
+      lagoon.sh/environmentType: production
+      lagoon.sh/project: example-project
+      lagoon.sh/service: basic1
+      lagoon.sh/service-type: network-policy
+      lagoon.sh/template: service-network-policy-0.1.0
+    name: basic1
+    namespace: example-project-main
+    resourceVersion: "1"
+  spec:
+    ingress:
+    - from:
+      - podSelector: {}
+      - namespaceSelector:
+          matchExpressions:
+          - key: lagoon.sh/project
+            operator: In
+            values:
+            - my-project
+          - key: lagoon.sh/environment
+            operator: In
+            values:
+            - main
+    - from:
+      - podSelector: {}
+      - namespaceSelector:
+          matchExpressions:
+          - key: lagoon.sh/project
+            operator: In
+            values:
+            - my-other-project
+          - key: lagoon.sh/environmentType
+            operator: In
+            values:
+            - production
+    - from:
+      - podSelector: {}
+      - namespaceSelector:
+          matchExpressions:
+          - key: organization.lagoon.sh/name
+            operator: In
+            values:
+            - nameoforg
+    - from:
+      - podSelector: {}
+      - namespaceSelector:
+          matchExpressions:
+          - key: organization.lagoon.sh/name
+            operator: In
+            values:
+            - anotherorg
+          - key: lagoon.sh/environmentType
+            operator: In
+            values:
+            - production
+    - from:
+      - podSelector: {}
+      - namespaceSelector:
+          matchExpressions:
+          - key: organization.lagoon.sh/name
+            operator: In
+            values:
+            - someotherorg
+          - key: lagoon.sh/project
+            operator: NotIn
+            values:
+            - projecta
+            - projectb
+    podSelector:
+      matchLabels:
+        lagoon.sh/service: basic1
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-postgres-consumers.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-postgres-consumers.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-prebackuppods-v1.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-prebackuppods-v1.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-prebackuppods-v1alpha1.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-prebackuppods-v1alpha1.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-schedules-v1.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-schedules-v1.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-schedules-v1alpha1.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-schedules-v1alpha1.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-secrets.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-secrets.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-services.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-services.yaml
@@ -1,0 +1,86 @@
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      lagoon.sh/branch: main
+      lagoon.sh/version: v2.7.x
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/instance: basic1
+      app.kubernetes.io/managed-by: build-deploy-tool
+      app.kubernetes.io/name: basic
+      lagoon.sh/buildType: branch
+      lagoon.sh/environment: main
+      lagoon.sh/environmentType: production
+      lagoon.sh/project: example-project
+      lagoon.sh/service: basic1
+      lagoon.sh/service-type: basic
+      lagoon.sh/template: basic-0.1.0
+    name: basic1
+    namespace: example-project-main
+    resourceVersion: "1"
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+    selector:
+      app.kubernetes.io/instance: basic1
+      app.kubernetes.io/name: basic
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      lagoon.sh/branch: main
+      lagoon.sh/version: v2.7.x
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/instance: basic2
+      app.kubernetes.io/managed-by: build-deploy-tool
+      app.kubernetes.io/name: external
+      lagoon.sh/buildType: branch
+      lagoon.sh/environment: main
+      lagoon.sh/environmentType: production
+      lagoon.sh/project: example-project
+      lagoon.sh/service: basic2
+      lagoon.sh/service-type: external
+      lagoon.sh/template: external-0.1.0
+    name: basic2
+    namespace: example-project-main
+    resourceVersion: "1"
+  spec:
+    externalName: basic.other-project-main.svc.cluster.local
+    type: ExternalName
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      lagoon.sh/branch: main
+      lagoon.sh/version: v2.7.x
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/instance: basic3
+      app.kubernetes.io/managed-by: build-deploy-tool
+      app.kubernetes.io/name: external
+      lagoon.sh/buildType: branch
+      lagoon.sh/environment: main
+      lagoon.sh/environmentType: production
+      lagoon.sh/project: example-project
+      lagoon.sh/service: basic3
+      lagoon.sh/service-type: external
+      lagoon.sh/template: external-0.1.0
+    name: basic3
+    namespace: example-project-main
+    resourceVersion: "1"
+  spec:
+    externalName: some-domain.example.com
+    type: ExternalName
+  status:
+    loadBalancer: {}
+metadata: {}

--- a/internal/collector/testdata/result/result-empty/lagoon-networkpolicies.yaml
+++ b/internal/collector/testdata/result/result-empty/lagoon-networkpolicies.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/seed/seed-3/deployment-basic1.yaml
+++ b/internal/collector/testdata/seed/seed-3/deployment-basic1.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic1
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: basic
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic1
+    lagoon.sh/service-type: basic
+    lagoon.sh/template: basic-0.1.0
+  name: basic1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: basic1
+      app.kubernetes.io/name: basic
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        lagoon.sh/branch: main
+        lagoon.sh/configMapSha: abcdefg1234567890
+        lagoon.sh/version: v2.7.x
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: basic1
+        app.kubernetes.io/managed-by: build-deploy-tool
+        app.kubernetes.io/name: basic
+        lagoon.sh/buildType: branch
+        lagoon.sh/environment: main
+        lagoon.sh/environmentType: production
+        lagoon.sh/project: example-project
+        lagoon.sh/service: basic1
+        lagoon.sh/service-type: basic
+        lagoon.sh/template: basic-0.1.0
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - env:
+        - name: LAGOON_GIT_SHA
+          value: abcdefg123456
+        - name: CRONJOBS
+        - name: SERVICE_NAME
+          value: basic1
+        envFrom:
+        - secretRef:
+            name: lagoon-platform-env
+        - secretRef:
+            name: lagoon-env
+        image: harbor.example/example-project/main/basic1@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8
+        imagePullPolicy: Always
+        livenessProbe:
+          initialDelaySeconds: 60
+          tcpSocket:
+            port: 8080
+          timeoutSeconds: 10
+        name: basic
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        readinessProbe:
+          initialDelaySeconds: 1
+          tcpSocket:
+            port: 8080
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext: {}
+      enableServiceLinks: false
+      imagePullSecrets:
+      - name: lagoon-internal-registry-secret
+      priorityClassName: lagoon-priority-production
+status: {}

--- a/internal/collector/testdata/seed/seed-3/networkpolicy-basic1.yaml
+++ b/internal/collector/testdata/seed/seed-3/networkpolicy-basic1.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: service-network-policy
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: service-network-policy
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic1
+    lagoon.sh/service-type: network-policy
+    lagoon.sh/template: service-network-policy-0.1.0
+  name: basic1
+spec:
+  ingress:
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: lagoon.sh/project
+          operator: In
+          values:
+          - my-project
+        - key: lagoon.sh/environment
+          operator: In
+          values:
+          - main
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: lagoon.sh/project
+          operator: In
+          values:
+          - my-other-project
+        - key: lagoon.sh/environmentType
+          operator: In
+          values:
+          - production
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: organization.lagoon.sh/name
+          operator: In
+          values:
+          - nameoforg
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: organization.lagoon.sh/name
+          operator: In
+          values:
+          - anotherorg
+        - key: lagoon.sh/environmentType
+          operator: In
+          values:
+          - production
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: organization.lagoon.sh/name
+          operator: In
+          values:
+          - someotherorg
+        - key: lagoon.sh/project
+          operator: NotIn
+          values:
+          - projecta
+          - projectb
+  podSelector:
+    matchLabels:
+      lagoon.sh/service: basic1

--- a/internal/collector/testdata/seed/seed-3/service-basic1.yaml
+++ b/internal/collector/testdata/seed/seed-3/service-basic1.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic1
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: basic
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic1
+    lagoon.sh/service-type: basic
+    lagoon.sh/template: basic-0.1.0
+  name: basic1
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: http
+  selector:
+    app.kubernetes.io/instance: basic1
+    app.kubernetes.io/name: basic
+status:
+  loadBalancer: {}

--- a/internal/collector/testdata/seed/seed-3/service-basic2.yaml
+++ b/internal/collector/testdata/seed/seed-3/service-basic2.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic2
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: external
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic2
+    lagoon.sh/service-type: external
+    lagoon.sh/template: external-0.1.0
+  name: basic2
+spec:
+  externalName: basic.other-project-main.svc.cluster.local
+  type: ExternalName
+status:
+  loadBalancer: {}

--- a/internal/collector/testdata/seed/seed-3/service-basic3.yaml
+++ b/internal/collector/testdata/seed/seed-3/service-basic3.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic3
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: external
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic3
+    lagoon.sh/service-type: external
+    lagoon.sh/template: external-0.1.0
+  name: basic3
+spec:
+  externalName: some-domain.example.com
+  type: ExternalName
+status:
+  loadBalancer: {}

--- a/internal/generator/buildvalues.go
+++ b/internal/generator/buildvalues.go
@@ -209,6 +209,14 @@ type ServiceValues struct {
 	IsSingle                               bool                    `json:"isSingle"`
 	AdditionalVolumes                      []ServiceVolume         `json:"additonalVolumes,omitempty"`
 	CreateDefaultVolume                    bool                    `json:"createDefaultVolume"`
+	ExternalServiceName                    string                  `json:"externalServiceName,omitempty"`
+}
+
+type ExternalService struct {
+	Name        string `json:"name,omitempty"`
+	Project     string `json:"project,omitempty"`
+	Environment string `json:"environment,omitempty"`
+	Domain      string `json:"domain,omitempty"`
 }
 
 type ImageBuild struct {

--- a/internal/generator/services.go
+++ b/internal/generator/services.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -14,6 +15,7 @@ import (
 	"github.com/uselagoon/build-deploy-tool/internal/helpers"
 	"github.com/uselagoon/build-deploy-tool/internal/lagoon"
 	"github.com/uselagoon/build-deploy-tool/internal/servicetypes"
+	machinerynamespace "github.com/uselagoon/machinery/utils/namespace"
 )
 
 // this is a map that maps old service types to their new service types
@@ -278,131 +280,9 @@ func composeToServiceValues(
 		}
 		// anything after this point is where heavy processing is done as the service type has now been determined by this stage
 
-		// handle dbaas operator checks here
-		dbaasEnvironment := buildValues.EnvironmentType
 		svcIsDBaaS := false
 		svcIsSingle := false
-		if helpers.Contains(supportedDBTypes, lagoonType) {
-			// strip the dbaas off the supplied type for checking against providers, it gets added again later
-			lagoonType = strings.Split(lagoonType, "-dbaas")[0]
-			err := buildValues.DBaaSClient.CheckHealth(buildValues.DBaaSOperatorEndpoint)
-			if err != nil {
-				// @TODO eventually this error should be handled and fail a build, with a flag to override https://github.com/uselagoon/build-deploy-tool/issues/56
-				// if !buildValues.DBaaSFallbackSingle {
-				// 	return nil, fmt.Errorf("unable to check the DBaaS endpoint %s: %v", buildValues.DBaaSOperatorEndpoint, err)
-				// }
-				if debug {
-					fmt.Printf("Unable to check the DBaaS endpoint %s, falling back to %s-single: %v\n", buildValues.DBaaSOperatorEndpoint, lagoonType, err)
-				}
-				// normally we would fall back to doing a cluster capability check, this is phased out in the build tool, it isn't reliable
-				// and noone should be doing checks that way any more
-				// the old bash check is the following
-				// elif [[ "${CAPABILITIES[@]}" =~ "mariadb.amazee.io/v1/MariaDBConsumer" ]] && ! checkDBaaSHealth ; then
-				lagoonType = fmt.Sprintf("%s-single", lagoonType)
-			} else {
-				// if there is a `lagoon.%s-dbaas.environment` label on this service, this should be used as an the environment type for the dbaas
-				dbaasLabelOverride := lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, fmt.Sprintf("lagoon.%s-dbaas.environment", lagoonType))
-				if dbaasLabelOverride != "" {
-					dbaasEnvironment = dbaasLabelOverride
-				}
-
-				// @TODO: maybe phase this out?
-				// if value, ok := buildValues.LagoonYAML.Environments[buildValues.Environment].Overrides[composeService][mariadb][mariadb-dbaas].Environment; ok {
-				// this isn't documented in the lagoon.yml, and it looks like a failover from days past.
-				// 	lagoonType = value
-				// }
-
-				// if there are overrides defined in the lagoon API `LAGOON_DBAAS_ENVIRONMENT_TYPES`
-				// handle those here
-				exists, err := getDBaasEnvironment(buildValues, &dbaasEnvironment, lagoonOverrideName, lagoonType)
-				if err != nil {
-					// @TODO eventually this error should be handled and fail a build, with a flag to override https://github.com/uselagoon/build-deploy-tool/issues/56
-					// if !buildValues.DBaaSFallbackSingle {
-					// 	return nil, err
-					// }
-					if debug {
-						fmt.Printf(
-							"There was an error checking DBaaS endpoint %s, falling back to %s-single: %v\n",
-							buildValues.DBaaSOperatorEndpoint, lagoonType, err,
-						)
-					}
-				}
-
-				// if the requested dbaas environment exists, then set the type to be the requested type with `-dbaas`
-				if exists {
-					lagoonType = fmt.Sprintf("%s-dbaas", lagoonType)
-					svcIsDBaaS = true
-				} else {
-					// otherwise fallback to -single (if DBaaSFallbackSingle is enabled, otherwise it will error out prior)
-					lagoonType = fmt.Sprintf("%s-single", lagoonType)
-					svcIsSingle = true
-				}
-			}
-		}
-
-		// check if the service has any persistent labels, this is the path that the volume will be mounted to
-		servicePersistentPath := lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, "lagoon.persistent")
-		if servicePersistentPath == "" {
-			// if there is no persistent path, check if the service type has a default path
-			if val, ok := servicetypes.ServiceTypes[lagoonType]; ok {
-				servicePersistentPath = val.Volumes.PersistentVolumePath
-				// check if the service type provides or consumes a default persistent volume
-				if (val.ProvidesPersistentVolume || val.ConsumesPersistentVolume) && servicePersistentPath == "" {
-					return nil, fmt.Errorf("label lagoon.persistent not defined for service %s, no valid mount path was found", composeService)
-				}
-			}
-		}
-		servicePersistentName := lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, "lagoon.persistent.name")
-		if servicePersistentName == "" && servicePersistentPath != "" {
-			// if there is a persistent path defined, then set the persistent name to be the compose service if no persistent name is provided
-			// persistent name is used by joined services like nginx/php or cli or worker pods to mount another service volume
-			servicePersistentName = lagoonOverrideName
-		}
-		servicePersistentSize := lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, "lagoon.persistent.size")
-		if servicePersistentSize == "" {
-			// if there is no persistent size, check if the service type has a default size allocated
-			if val, ok := servicetypes.ServiceTypes[lagoonType]; ok {
-				servicePersistentSize = val.Volumes.PersistentVolumeSize
-				// check if the service type provides persistent volume, and that a size was detected
-				if val.ProvidesPersistentVolume && servicePersistentSize == "" {
-					return nil, fmt.Errorf("label lagoon.persistent.size not defined for service %s, no valid size was found", composeService)
-				}
-			}
-		}
-		if servicePersistentSize != "" {
-			// check the provided size is a valid resource size for kubernetes
-			_, err := ValidateResourceSize(servicePersistentSize)
-			if err != nil {
-				return nil, fmt.Errorf("provided persistent volume size for %s is not valid: %v", servicePersistentName, err)
-			}
-		}
-
-		// if any `lagoon.base.image` labels are set, we note them for docker pulling
-		// this allows us to refresh the docker-host's cache in cases where an image
-		// may have an update without a change in tag (i.e. "latest" tagged images)
-		baseimage := lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, "lagoon.base.image")
-		if baseimage != "" {
-			baseImageWithTag, errs := determineRefreshImage(composeService, baseimage, buildValues.EnvironmentVariables)
-			if len(errs) > 0 {
-				for idx, err := range errs {
-					if idx+1 == len(errs) {
-						return nil, err
-					} else {
-						fmt.Println(err)
-					}
-				}
-			}
-			buildValues.ForcePullImages = append(buildValues.ForcePullImages, baseImageWithTag)
-		}
-
-		// calculate if this service needs any additional volumes attached from the calculated build volumes
-		// additional volumes can only be attached to certain
-		serviceVolumes, err := calculateServiceVolumes(buildValues, lagoonType, servicePersistentName, composeServiceValues.Labels)
-		if err != nil {
-			return nil, err
-		}
-
-		// start spot instance handling
+		backupsEnabled := false
 		useSpot := false
 		forceSpot := false
 		cronjobUseSpot := false
@@ -410,142 +290,292 @@ func composeToServiceValues(
 		spotTypes := ""
 		cronjobSpotTypes := ""
 		spotReplicas := int32(0)
-
-		// these services can support multiple replicas in production
-		// @TODO this should probably be an admin only feature flag though
-		prodSpotReplicaTypes := CheckAdminFeatureFlag("SPOT_TYPE_REPLICAS_PRODUCTION", debug)
-		if prodSpotReplicaTypes == "" {
-			prodSpotReplicaTypes = "nginx,nginx-persistent,nginx-php,nginx-php-persistent"
-		}
-		devSpotReplicaTypes := CheckAdminFeatureFlag("SPOT_TYPE_REPLICAS_DEVELOPMENT", debug)
-		if devSpotReplicaTypes == "" {
-			devSpotReplicaTypes = ""
-		}
-
-		productionSpot := CheckFeatureFlag("SPOT_INSTANCE_PRODUCTION", buildValues.EnvironmentVariables, debug)
-		developmentSpot := CheckFeatureFlag("SPOT_INSTANCE_DEVELOPMENT", buildValues.EnvironmentVariables, debug)
-		if productionSpot == "enabled" && buildValues.EnvironmentType == "production" {
-			spotTypes = CheckFeatureFlag("SPOT_INSTANCE_PRODUCTION_TYPES", buildValues.EnvironmentVariables, debug)
-			cronjobSpotTypes = CheckFeatureFlag("SPOT_INSTANCE_PRODUCTION_CRONJOB_TYPES", buildValues.EnvironmentVariables, debug)
-		}
-		if developmentSpot == "enabled" && buildValues.EnvironmentType == "development" {
-			spotTypes = CheckFeatureFlag("SPOT_INSTANCE_DEVELOPMENT_TYPES", buildValues.EnvironmentVariables, debug)
-			cronjobSpotTypes = CheckFeatureFlag("SPOT_INSTANCE_DEVELOPMENT_CRONJOB_TYPES", buildValues.EnvironmentVariables, debug)
-		}
-		// check if the provided spot instance types against the current lagoonType
-		for _, t := range strings.Split(spotTypes, ",") {
-			if t != "" {
-				tt := strings.Split(t, ":")
-				if tt[0] == lagoonType {
-					useSpot = true
-					// check if the length of the split is more than one indicating that `force` is provided
-					if len(tt) > 1 && tt[1] == "force" {
-						forceSpot = true
-					}
-				}
-			}
-		}
-		// check if the provided cronjob spot instance types against the current lagoonType
-		for _, t := range strings.Split(cronjobSpotTypes, ",") {
-			if t != "" {
-				tt := strings.Split(t, ":")
-				if tt[0] == lagoonType {
-					cronjobUseSpot = true
-					// check if the length of the split is more than one indicating that `force` is provided
-					if len(tt) > 1 && tt[1] == "force" {
-						cronjobForceSpot = true
-					}
-				}
-			}
-		}
-		// check if the this service is production and can support 2 replicas on spot
-		for _, t := range strings.Split(prodSpotReplicaTypes, ",") {
-			if t != "" {
-				if t == lagoonType && buildValues.EnvironmentType == "production" && useSpot {
-					spotReplicas = 2
-				}
-			}
-		}
-		for _, t := range strings.Split(devSpotReplicaTypes, ",") {
-			if t != "" {
-				if t == lagoonType && buildValues.EnvironmentType == "development" && useSpot {
-					spotReplicas = 2
-				}
-			}
-		}
-		// end spot instance handling
-
-		// work out cronjobs for this service
+		servicePersistentPath := ""
+		servicePersistentName := ""
+		servicePersistentSize := ""
 		inpodcronjobs := []lagoon.Cronjob{}
 		nativecronjobs := []lagoon.Cronjob{}
-		// check if there are any duplicate named cronjobs
-		if err := checkDuplicateCronjobs(buildValues.LagoonYAML.Environments[buildValues.Branch].Cronjobs); err != nil {
-			return nil, err
-		}
-		if !buildValues.CronjobsDisabled {
-			for idx, cronjob := range buildValues.LagoonYAML.Environments[buildValues.Branch].Cronjobs {
-				// if this cronjob is meant for this service, add it
-				if cronjob.Service == composeService {
-					var err error
-					inpod, err := helpers.IsInPodCronjob(cronjob.Schedule)
+		dbaasEnvironment := buildValues.EnvironmentType
+		externalName := ""
+		var serviceVolumes []ServiceVolume
+		var err error
+		if lagoonType == "external" {
+			esLabel := lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, "lagoon.external.service")
+			if esLabel == "" {
+				return nil, fmt.Errorf(
+					"lagoon.type external has been set for service %s, yet no 'lagoon.external.service' label was defined",
+					composeService,
+				)
+			}
+			externalService := &ExternalService{}
+			if err := json.Unmarshal([]byte(esLabel), externalService); err != nil {
+				return nil, fmt.Errorf(
+					"error encountered decoding label 'lagoon.external.service' for service %s, is it JSON?",
+					composeService,
+				)
+			}
+			if externalService.Domain == "" {
+				externalName = fmt.Sprintf("%s.%s.svc.cluster.local", externalService.Name, machinerynamespace.GenerateNamespaceName("", externalService.Environment, externalService.Project, "", "", false))
+			} else {
+				externalName = externalService.Domain
+			}
+		} else {
+			// handle dbaas operator checks here
+			if helpers.Contains(supportedDBTypes, lagoonType) {
+				// strip the dbaas off the supplied type for checking against providers, it gets added again later
+				lagoonType = strings.Split(lagoonType, "-dbaas")[0]
+				err := buildValues.DBaaSClient.CheckHealth(buildValues.DBaaSOperatorEndpoint)
+				if err != nil {
+					// @TODO eventually this error should be handled and fail a build, with a flag to override https://github.com/uselagoon/build-deploy-tool/issues/56
+					// if !buildValues.DBaaSFallbackSingle {
+					// 	return nil, fmt.Errorf("unable to check the DBaaS endpoint %s: %v", buildValues.DBaaSOperatorEndpoint, err)
+					// }
+					if debug {
+						fmt.Printf("Unable to check the DBaaS endpoint %s, falling back to %s-single: %v\n", buildValues.DBaaSOperatorEndpoint, lagoonType, err)
+					}
+					// normally we would fall back to doing a cluster capability check, this is phased out in the build tool, it isn't reliable
+					// and noone should be doing checks that way any more
+					// the old bash check is the following
+					// elif [[ "${CAPABILITIES[@]}" =~ "mariadb.amazee.io/v1/MariaDBConsumer" ]] && ! checkDBaaSHealth ; then
+					lagoonType = fmt.Sprintf("%s-single", lagoonType)
+				} else {
+					// if there is a `lagoon.%s-dbaas.environment` label on this service, this should be used as an the environment type for the dbaas
+					dbaasLabelOverride := lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, fmt.Sprintf("lagoon.%s-dbaas.environment", lagoonType))
+					if dbaasLabelOverride != "" {
+						dbaasEnvironment = dbaasLabelOverride
+					}
+
+					// @TODO: maybe phase this out?
+					// if value, ok := buildValues.LagoonYAML.Environments[buildValues.Environment].Overrides[composeService][mariadb][mariadb-dbaas].Environment; ok {
+					// this isn't documented in the lagoon.yml, and it looks like a failover from days past.
+					// 	lagoonType = value
+					// }
+
+					// if there are overrides defined in the lagoon API `LAGOON_DBAAS_ENVIRONMENT_TYPES`
+					// handle those here
+					exists, err := getDBaasEnvironment(buildValues, &dbaasEnvironment, lagoonOverrideName, lagoonType)
 					if err != nil {
-						return nil, fmt.Errorf("unable to validate crontab for cronjob %s: %v", cronjob.Name, err)
-					}
-					cronjob.Schedule, err = helpers.ConvertCrontab(buildValues.Namespace, cronjob.Schedule)
-					if err != nil {
-						return nil, fmt.Errorf("unable to convert crontab for cronjob %s: %v", cronjob.Name, err)
-					}
-					// handle setting the cronjob timeout here
-					// can't be greater than 24hrs and must match go time duration https://pkg.go.dev/time#ParseDuration
-					if cronjob.Timeout != "" {
-						cronjobTimeout, err := time.ParseDuration(cronjob.Timeout)
-						if err != nil {
-							return nil, fmt.Errorf("unable to convert timeout for cronjob %s: %v", cronjob.Name, err)
+						// @TODO eventually this error should be handled and fail a build, with a flag to override https://github.com/uselagoon/build-deploy-tool/issues/56
+						// if !buildValues.DBaaSFallbackSingle {
+						// 	return nil, err
+						// }
+						if debug {
+							fmt.Printf(
+								"There was an error checking DBaaS endpoint %s, falling back to %s-single: %v\n",
+								buildValues.DBaaSOperatorEndpoint, lagoonType, err,
+							)
 						}
-						// max cronjob timeout is 24 hours
-						if cronjobTimeout > time.Duration(24*time.Hour) {
-							return nil, fmt.Errorf("timeout for cronjob %s cannot be longer than 24 hours", cronjob.Name)
-						}
+					}
+
+					// if the requested dbaas environment exists, then set the type to be the requested type with `-dbaas`
+					if exists {
+						lagoonType = fmt.Sprintf("%s-dbaas", lagoonType)
+						svcIsDBaaS = true
 					} else {
-						// default cronjob timeout is 4h
-						cronjob.Timeout = "4h"
-					}
-					// if the cronjob is inpod, or the cronjob has an inpod flag override
-					if inpod || (cronjob.InPod != nil && *cronjob.InPod) {
-						cmd := cronjob.Command
-						// Lagoon enforces that only a single instance of a cronjob can run at any one time.
-						// https://man7.org/linux/man-pages/man1/flock.1.html
-						// https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Shell-Parameter-Expansion
-						sha := sha256.New()
-						sha.Write([]byte(fmt.Sprintf("%d %s", idx, cmd)))
-						cmdSha := sha.Sum(nil)
-						cronjob.Command = fmt.Sprintf("flock -n /tmp/cron.lock.%x -c %s", cmdSha, shellescape.Quote(cmd))
-						inpodcronjobs = append(inpodcronjobs, cronjob)
-					} else {
-						// make the cronjob name kubernetes compliant
-						cronjob.Name = regexp.MustCompile(`[^a-zA-Z0-9]+`).ReplaceAllString(fmt.Sprintf("cronjob-%s-%s", lagoonOverrideName, strings.ToLower(cronjob.Name)), "-")
-						if len(cronjob.Name) > 52 {
-							// if the cronjob name is longer than 52 characters
-							// truncate it and add a hash of the name to it
-							cronjob.Name = fmt.Sprintf("%s-%s", cronjob.Name[:45], helpers.GetBase32EncodedLowercase(helpers.GetSha256Hash(cronjob.Name))[:6])
-						}
-						nativecronjobs = append(nativecronjobs, cronjob)
+						// otherwise fallback to -single (if DBaaSFallbackSingle is enabled, otherwise it will error out prior)
+						lagoonType = fmt.Sprintf("%s-single", lagoonType)
+						svcIsSingle = true
 					}
 				}
 			}
-		}
 
-		// check if this service is one that supports autogenerated routes
-		if !helpers.Contains(supportedAutogeneratedTypes, lagoonType) {
-			autogenEnabled = false
-			autogenTLSAcmeEnabled = false
-		}
+			// check if the service has any persistent labels, this is the path that the volume will be mounted to
+			servicePersistentPath = lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, "lagoon.persistent")
+			if servicePersistentPath == "" {
+				// if there is no persistent path, check if the service type has a default path
+				if val, ok := servicetypes.ServiceTypes[lagoonType]; ok {
+					servicePersistentPath = val.Volumes.PersistentVolumePath
+					// check if the service type provides or consumes a default persistent volume
+					if (val.ProvidesPersistentVolume || val.ConsumesPersistentVolume) && servicePersistentPath == "" {
+						return nil, fmt.Errorf("label lagoon.persistent not defined for service %s, no valid mount path was found", composeService)
+					}
+				}
+			}
+			servicePersistentName = lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, "lagoon.persistent.name")
+			if servicePersistentName == "" && servicePersistentPath != "" {
+				// if there is a persistent path defined, then set the persistent name to be the compose service if no persistent name is provided
+				// persistent name is used by joined services like nginx/php or cli or worker pods to mount another service volume
+				servicePersistentName = lagoonOverrideName
+			}
+			servicePersistentSize = lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, "lagoon.persistent.size")
+			if servicePersistentSize == "" {
+				// if there is no persistent size, check if the service type has a default size allocated
+				if val, ok := servicetypes.ServiceTypes[lagoonType]; ok {
+					servicePersistentSize = val.Volumes.PersistentVolumeSize
+					// check if the service type provides persistent volume, and that a size was detected
+					if val.ProvidesPersistentVolume && servicePersistentSize == "" {
+						return nil, fmt.Errorf("label lagoon.persistent.size not defined for service %s, no valid size was found", composeService)
+					}
+				}
+			}
+			if servicePersistentSize != "" {
+				// check the provided size is a valid resource size for kubernetes
+				_, err := ValidateResourceSize(servicePersistentSize)
+				if err != nil {
+					return nil, fmt.Errorf("provided persistent volume size for %s is not valid: %v", servicePersistentName, err)
+				}
+			}
 
-		// check if this service is one that supports backups
-		backupsEnabled := false
-		if helpers.Contains(typesWithBackups, lagoonType) {
-			backupsEnabled = true
+			// if any `lagoon.base.image` labels are set, we note them for docker pulling
+			// this allows us to refresh the docker-host's cache in cases where an image
+			// may have an update without a change in tag (i.e. "latest" tagged images)
+			baseimage := lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, "lagoon.base.image")
+			if baseimage != "" {
+				baseImageWithTag, errs := determineRefreshImage(composeService, baseimage, buildValues.EnvironmentVariables)
+				if len(errs) > 0 {
+					for idx, err := range errs {
+						if idx+1 == len(errs) {
+							return nil, err
+						} else {
+							fmt.Println(err)
+						}
+					}
+				}
+				buildValues.ForcePullImages = append(buildValues.ForcePullImages, baseImageWithTag)
+			}
 
+			// calculate if this service needs any additional volumes attached from the calculated build volumes
+			// additional volumes can only be attached to certain
+			serviceVolumes, err = calculateServiceVolumes(buildValues, lagoonType, servicePersistentName, composeServiceValues.Labels)
+			if err != nil {
+				return nil, err
+			}
+
+			// start spot instance handling
+
+			// these services can support multiple replicas in production
+			// @TODO this should probably be an admin only feature flag though
+			prodSpotReplicaTypes := CheckAdminFeatureFlag("SPOT_TYPE_REPLICAS_PRODUCTION", debug)
+			if prodSpotReplicaTypes == "" {
+				prodSpotReplicaTypes = "nginx,nginx-persistent,nginx-php,nginx-php-persistent"
+			}
+			devSpotReplicaTypes := CheckAdminFeatureFlag("SPOT_TYPE_REPLICAS_DEVELOPMENT", debug)
+			if devSpotReplicaTypes == "" {
+				devSpotReplicaTypes = ""
+			}
+
+			productionSpot := CheckFeatureFlag("SPOT_INSTANCE_PRODUCTION", buildValues.EnvironmentVariables, debug)
+			developmentSpot := CheckFeatureFlag("SPOT_INSTANCE_DEVELOPMENT", buildValues.EnvironmentVariables, debug)
+			if productionSpot == "enabled" && buildValues.EnvironmentType == "production" {
+				spotTypes = CheckFeatureFlag("SPOT_INSTANCE_PRODUCTION_TYPES", buildValues.EnvironmentVariables, debug)
+				cronjobSpotTypes = CheckFeatureFlag("SPOT_INSTANCE_PRODUCTION_CRONJOB_TYPES", buildValues.EnvironmentVariables, debug)
+			}
+			if developmentSpot == "enabled" && buildValues.EnvironmentType == "development" {
+				spotTypes = CheckFeatureFlag("SPOT_INSTANCE_DEVELOPMENT_TYPES", buildValues.EnvironmentVariables, debug)
+				cronjobSpotTypes = CheckFeatureFlag("SPOT_INSTANCE_DEVELOPMENT_CRONJOB_TYPES", buildValues.EnvironmentVariables, debug)
+			}
+			// check if the provided spot instance types against the current lagoonType
+			for _, t := range strings.Split(spotTypes, ",") {
+				if t != "" {
+					tt := strings.Split(t, ":")
+					if tt[0] == lagoonType {
+						useSpot = true
+						// check if the length of the split is more than one indicating that `force` is provided
+						if len(tt) > 1 && tt[1] == "force" {
+							forceSpot = true
+						}
+					}
+				}
+			}
+			// check if the provided cronjob spot instance types against the current lagoonType
+			for _, t := range strings.Split(cronjobSpotTypes, ",") {
+				if t != "" {
+					tt := strings.Split(t, ":")
+					if tt[0] == lagoonType {
+						cronjobUseSpot = true
+						// check if the length of the split is more than one indicating that `force` is provided
+						if len(tt) > 1 && tt[1] == "force" {
+							cronjobForceSpot = true
+						}
+					}
+				}
+			}
+			// check if the this service is production and can support 2 replicas on spot
+			for _, t := range strings.Split(prodSpotReplicaTypes, ",") {
+				if t != "" {
+					if t == lagoonType && buildValues.EnvironmentType == "production" && useSpot {
+						spotReplicas = 2
+					}
+				}
+			}
+			for _, t := range strings.Split(devSpotReplicaTypes, ",") {
+				if t != "" {
+					if t == lagoonType && buildValues.EnvironmentType == "development" && useSpot {
+						spotReplicas = 2
+					}
+				}
+			}
+			// end spot instance handling
+
+			// work out cronjobs for this service
+			// check if there are any duplicate named cronjobs
+			if err := checkDuplicateCronjobs(buildValues.LagoonYAML.Environments[buildValues.Branch].Cronjobs); err != nil {
+				return nil, err
+			}
+			if !buildValues.CronjobsDisabled {
+				for idx, cronjob := range buildValues.LagoonYAML.Environments[buildValues.Branch].Cronjobs {
+					// if this cronjob is meant for this service, add it
+					if cronjob.Service == composeService {
+						var err error
+						inpod, err := helpers.IsInPodCronjob(cronjob.Schedule)
+						if err != nil {
+							return nil, fmt.Errorf("unable to validate crontab for cronjob %s: %v", cronjob.Name, err)
+						}
+						cronjob.Schedule, err = helpers.ConvertCrontab(buildValues.Namespace, cronjob.Schedule)
+						if err != nil {
+							return nil, fmt.Errorf("unable to convert crontab for cronjob %s: %v", cronjob.Name, err)
+						}
+						// handle setting the cronjob timeout here
+						// can't be greater than 24hrs and must match go time duration https://pkg.go.dev/time#ParseDuration
+						if cronjob.Timeout != "" {
+							cronjobTimeout, err := time.ParseDuration(cronjob.Timeout)
+							if err != nil {
+								return nil, fmt.Errorf("unable to convert timeout for cronjob %s: %v", cronjob.Name, err)
+							}
+							// max cronjob timeout is 24 hours
+							if cronjobTimeout > time.Duration(24*time.Hour) {
+								return nil, fmt.Errorf("timeout for cronjob %s cannot be longer than 24 hours", cronjob.Name)
+							}
+						} else {
+							// default cronjob timeout is 4h
+							cronjob.Timeout = "4h"
+						}
+						// if the cronjob is inpod, or the cronjob has an inpod flag override
+						if inpod || (cronjob.InPod != nil && *cronjob.InPod) {
+							cmd := cronjob.Command
+							// Lagoon enforces that only a single instance of a cronjob can run at any one time.
+							// https://man7.org/linux/man-pages/man1/flock.1.html
+							// https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Shell-Parameter-Expansion
+							sha := sha256.New()
+							sha.Write([]byte(fmt.Sprintf("%d %s", idx, cmd)))
+							cmdSha := sha.Sum(nil)
+							cronjob.Command = fmt.Sprintf("flock -n /tmp/cron.lock.%x -c %s", cmdSha, shellescape.Quote(cmd))
+							inpodcronjobs = append(inpodcronjobs, cronjob)
+						} else {
+							// make the cronjob name kubernetes compliant
+							cronjob.Name = regexp.MustCompile(`[^a-zA-Z0-9]+`).ReplaceAllString(fmt.Sprintf("cronjob-%s-%s", lagoonOverrideName, strings.ToLower(cronjob.Name)), "-")
+							if len(cronjob.Name) > 52 {
+								// if the cronjob name is longer than 52 characters
+								// truncate it and add a hash of the name to it
+								cronjob.Name = fmt.Sprintf("%s-%s", cronjob.Name[:45], helpers.GetBase32EncodedLowercase(helpers.GetSha256Hash(cronjob.Name))[:6])
+							}
+							nativecronjobs = append(nativecronjobs, cronjob)
+						}
+					}
+				}
+			}
+
+			// check if this service is one that supports autogenerated routes
+			if !helpers.Contains(supportedAutogeneratedTypes, lagoonType) {
+				autogenEnabled = false
+				autogenTLSAcmeEnabled = false
+			}
+
+			// check if this service is one that supports backups
+			if helpers.Contains(typesWithBackups, lagoonType) {
+				backupsEnabled = true
+
+			}
 		}
 
 		// create the service values
@@ -572,6 +602,7 @@ func composeToServiceValues(
 			IsSingle:                               svcIsSingle,
 			BackupsEnabled:                         backupsEnabled,
 			AdditionalVolumes:                      serviceVolumes,
+			ExternalServiceName:                    externalName,
 		}
 
 		// work out the images here and the associated dockerfile and contexts

--- a/internal/lagoon/lagoon.go
+++ b/internal/lagoon/lagoon.go
@@ -131,10 +131,9 @@ type NetworkPolicy struct {
 }
 
 type OrgNetworkPolicies struct {
-	Name                string           `json:"name"`
-	EnvironmentType     string           `json:"environment-type,omitempty"`
-	ExcludeProjects     []ExcludeProject `json:"exclude-projects,omitempty"`
-	ExcludePullrequests bool             `json:"exclude-pullrequests,omitempty"`
+	Name            string           `json:"name"`
+	EnvironmentType string           `json:"environment-type,omitempty"`
+	ExcludeProjects []ExcludeProject `json:"exclude-projects,omitempty"`
 }
 
 type ProjectNetworkPolicies struct {

--- a/internal/lagoon/lagoon.go
+++ b/internal/lagoon/lagoon.go
@@ -26,6 +26,7 @@ type Environment struct {
 	Cronjobs               []Cronjob               `json:"cronjobs"`
 	Overrides              map[string]Override     `json:"overrides,omitempty"`
 	AutogeneratePathRoutes []AutogeneratePathRoute `json:"autogeneratePathRoutes,omitempty"`
+	NetworkPolicies        []NetworkPolicy         `json:"network-policies,omitempty"`
 }
 
 // Cronjob represents a Lagoon cronjob.
@@ -73,6 +74,7 @@ type YAML struct {
 	BackupSchedule       BackupSchedule               `json:"backup-schedule"`
 	EnvironmentVariables EnvironmentVariables         `json:"environment_variables,omitempty"`
 	ContainerRegistries  map[string]ContainerRegistry `json:"container-registries,omitempty"`
+	NetworkPolicies      []NetworkPolicy              `json:"network-policies,omitempty"`
 }
 
 type ContainerRegistry struct {
@@ -120,6 +122,35 @@ type Autogenerate struct {
 type AutogeneratePathRoute struct {
 	PathRoute
 	FromService string `json:"fromService"`
+}
+
+type NetworkPolicy struct {
+	Service       string                   `json:"service"`
+	Organizations []OrgNetworkPolicies     `json:"organizations"`
+	Projects      []ProjectNetworkPolicies `json:"projects"`
+}
+
+type OrgNetworkPolicies struct {
+	Name                string           `json:"name"`
+	EnvironmentType     string           `json:"environment-type,omitempty"`
+	ExcludeProjects     []ExcludeProject `json:"exclude-projects,omitempty"`
+	ExcludePullrequests bool             `json:"exclude-pullrequests,omitempty"`
+}
+
+type ProjectNetworkPolicies struct {
+	Name                string               `json:"name"`
+	Environment         string               `json:"environment,omitempty"`
+	EnvironmentType     string               `json:"environment-type,omitempty"`
+	ExcludeEnvironments []ExcludeEnvironment `json:"exclude-environments,omitempty"`
+	ExcludePullrequests bool                 `json:"exclude-pullrequests,omitempty"`
+}
+
+type ExcludeProject struct {
+	Name string `json:"name"`
+}
+
+type ExcludeEnvironment struct {
+	Name string `json:"name"`
 }
 
 func (a *Routes) UnmarshalJSON(data []byte) error {

--- a/internal/servicetypes/external.go
+++ b/internal/servicetypes/external.go
@@ -1,0 +1,7 @@
+package servicetypes
+
+// defines an external service type
+// this type doesn't have any associated data so this just acts as a placeholder
+var external = ServiceType{
+	Name: "external",
+}

--- a/internal/servicetypes/types.go
+++ b/internal/servicetypes/types.go
@@ -88,4 +88,5 @@ var ServiceTypes = map[string]ServiceType{
 	"worker":               worker,
 	"worker-persistent":    workerPersistent,
 	"rabbitmq":             rabbitmq,
+	"external":             external,
 }

--- a/internal/templating/template_networkpolicy.go
+++ b/internal/templating/template_networkpolicy.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/uselagoon/build-deploy-tool/internal/generator"
+	"github.com/uselagoon/build-deploy-tool/internal/lagoon"
+	machineryns "github.com/uselagoon/machinery/utils/namespace"
 	networkv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
@@ -76,6 +78,87 @@ func GenerateNetworkPolicy(
 	return &np, nil
 }
 
+// GenerateServiceNetworkPolicies will generate any networkpolicies required for specific services if defined in the lagoon.yml file
+func GenerateServiceNetworkPolicies(
+	buildValues generator.BuildValues,
+) ([]networkv1.NetworkPolicy, error) {
+	var nps []networkv1.NetworkPolicy
+
+	// default is to set the network policies to whatever is at the root of the lagoon.yml if provided
+	lagoonNetworkPolicies := buildValues.LagoonYAML.NetworkPolicies
+	// check if the environment has specific network policies, these should be used instead
+	// they aren't stacked or added to the root network policies, they will replace them
+	if buildValues.LagoonYAML.Environments[buildValues.Environment].NetworkPolicies != nil {
+		lagoonNetworkPolicies = buildValues.LagoonYAML.Environments[buildValues.Environment].NetworkPolicies
+	}
+	if lagoonNetworkPolicies != nil {
+		// add the default annotations
+		annotations := map[string]string{
+			"lagoon.sh/version": buildValues.LagoonVersion,
+		}
+
+		// add any additional labels
+		if buildValues.BuildType == "branch" {
+			annotations["lagoon.sh/branch"] = buildValues.Branch
+		} else if buildValues.BuildType == "pullrequest" {
+			annotations["lagoon.sh/prNumber"] = buildValues.PRNumber
+			annotations["lagoon.sh/prHeadBranch"] = buildValues.PRHeadBranch
+			annotations["lagoon.sh/prBaseBranch"] = buildValues.PRBaseBranch
+		}
+
+		for _, netpol := range lagoonNetworkPolicies {
+			// add the default labels
+			labels := map[string]string{
+				"app.kubernetes.io/managed-by": "build-deploy-tool",
+				"app.kubernetes.io/instance":   "service-network-policy",
+				"app.kubernetes.io/name":       "service-network-policy",
+				"lagoon.sh/template":           "service-network-policy-0.1.0",
+				"lagoon.sh/project":            buildValues.Project,
+				"lagoon.sh/environment":        buildValues.Environment,
+				"lagoon.sh/environmentType":    buildValues.EnvironmentType,
+				"lagoon.sh/buildType":          buildValues.BuildType,
+				"lagoon.sh/service":            netpol.Service,
+				"lagoon.sh/service-type":       "network-policy",
+			}
+
+			// work out the policies for the specific service from the .lagoon.yml file here
+			var npirs []networkv1.NetworkPolicyIngressRule
+			for _, pp := range netpol.Projects {
+				// this generates any project specific policies
+				npirs = append(npirs, generateProjectIngressRule(pp))
+			}
+
+			for _, op := range netpol.Organizations {
+				// this generates any organization specific policies
+				npirs = append(npirs, generateOrganizationIngressRule(op))
+			}
+			np := networkv1.NetworkPolicy{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "NetworkPolicy",
+					APIVersion: "networking.k8s.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        netpol.Service,
+					Labels:      labels,
+					Annotations: annotations,
+				},
+				Spec: networkv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							// set the podselector to be that of the requested service, all other policies defined in the .lagoon.yml file
+							// will get enerated above
+							"lagoon.sh/service": netpol.Service,
+						},
+					},
+					Ingress: npirs,
+				},
+			}
+			nps = append(nps, np)
+		}
+	}
+	return nps, nil
+}
+
 func TemplateNetworkPolicy(ingress *networkv1.NetworkPolicy) ([]byte, error) {
 	separator := []byte("---\n")
 	var templateYAML []byte
@@ -86,4 +169,100 @@ func TemplateNetworkPolicy(ingress *networkv1.NetworkPolicy) ([]byte, error) {
 	restoreResult := append(separator[:], iBytes[:]...)
 	templateYAML = append(templateYAML, restoreResult[:]...)
 	return templateYAML, nil
+}
+
+func generateProjectIngressRule(pp lagoon.ProjectNetworkPolicies) networkv1.NetworkPolicyIngressRule {
+	namespaceSelectors := []metav1.LabelSelectorRequirement{
+		{
+			Key:      "lagoon.sh/project",
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{pp.Name},
+		},
+	}
+	if pp.Environment != "" {
+		environmentName := machineryns.ShortenEnvironment(pp.Name, machineryns.MakeSafe(pp.Environment))
+		namespaceSelectors = append(namespaceSelectors, metav1.LabelSelectorRequirement{
+			Key:      "lagoon.sh/environment",
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{environmentName},
+		})
+	}
+	if pp.EnvironmentType != "" {
+		namespaceSelectors = append(namespaceSelectors, metav1.LabelSelectorRequirement{
+			Key:      "lagoon.sh/environmentType",
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{pp.EnvironmentType},
+		})
+	}
+	if pp.ExcludeEnvironments != nil {
+		lagoonEnvironments := []string{}
+		for _, exEnv := range pp.ExcludeEnvironments {
+			lagoonEnvironments = append(lagoonEnvironments, machineryns.ShortenEnvironment(pp.Name, machineryns.MakeSafe(exEnv.Name)))
+		}
+		namespaceSelectors = append(namespaceSelectors, metav1.LabelSelectorRequirement{
+			Key:      "lagoon.sh/environment",
+			Operator: metav1.LabelSelectorOpNotIn,
+			Values:   lagoonEnvironments,
+		})
+	}
+	if pp.ExcludePullrequests {
+		namespaceSelectors = append(namespaceSelectors, metav1.LabelSelectorRequirement{
+			Key:      "lagoon.sh/buildType",
+			Operator: metav1.LabelSelectorOpNotIn,
+			Values:   []string{"pullrequest"},
+		})
+	}
+
+	return networkv1.NetworkPolicyIngressRule{
+		From: []networkv1.NetworkPolicyPeer{
+			{
+				PodSelector: &metav1.LabelSelector{},
+			},
+			{
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchExpressions: namespaceSelectors,
+				},
+			},
+		},
+	}
+}
+
+func generateOrganizationIngressRule(op lagoon.OrgNetworkPolicies) networkv1.NetworkPolicyIngressRule {
+	namespaceSelectors := []metav1.LabelSelectorRequirement{
+		{
+			Key:      "organization.lagoon.sh/name",
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{op.Name},
+		},
+	}
+	if op.EnvironmentType != "" {
+		namespaceSelectors = append(namespaceSelectors, metav1.LabelSelectorRequirement{
+			Key:      "lagoon.sh/environmentType",
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{op.EnvironmentType},
+		})
+	}
+	if op.ExcludeProjects != nil {
+		lagoonProjects := []string{}
+		for _, exEnv := range op.ExcludeProjects {
+			lagoonProjects = append(lagoonProjects, machineryns.MakeSafe(exEnv.Name))
+		}
+		namespaceSelectors = append(namespaceSelectors, metav1.LabelSelectorRequirement{
+			Key:      "lagoon.sh/project",
+			Operator: metav1.LabelSelectorOpNotIn,
+			Values:   lagoonProjects,
+		})
+	}
+	return networkv1.NetworkPolicyIngressRule{
+		From: []networkv1.NetworkPolicyPeer{
+			{
+				PodSelector: &metav1.LabelSelector{},
+			},
+			{
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchExpressions: namespaceSelectors,
+				},
+			},
+		},
+	}
 }

--- a/internal/templating/templates_cronjob.go
+++ b/internal/templating/templates_cronjob.go
@@ -27,7 +27,7 @@ func GenerateCronjobTemplate(
 	// for all the services that the build values generated
 	// iterate over them and generate any kubernetes cronjobs
 	for _, serviceValues := range checkedServices {
-		if val, ok := servicetypes.ServiceTypes[serviceValues.Type]; ok {
+		if val, ok := servicetypes.ServiceTypes[serviceValues.Type]; ok && serviceValues.Type != "external" {
 			for _, nCronjob := range serviceValues.NativeCronjobs {
 				serviceTypeValues := &servicetypes.ServiceType{}
 				helpers.DeepCopy(val, serviceTypeValues)

--- a/internal/templating/templates_deployment.go
+++ b/internal/templating/templates_deployment.go
@@ -26,7 +26,7 @@ func GenerateDeploymentTemplate(
 	// for all the services that the build values generated
 	// iterate over them and generate any kubernetes deployments
 	for _, serviceValues := range checkedServices {
-		if val, ok := servicetypes.ServiceTypes[serviceValues.Type]; ok {
+		if val, ok := servicetypes.ServiceTypes[serviceValues.Type]; ok && serviceValues.Type != "external" {
 			serviceTypeValues := &servicetypes.ServiceType{}
 			helpers.DeepCopy(val, serviceTypeValues)
 

--- a/internal/testdata/basic/docker-compose.basic-externalservice.yml
+++ b/internal/testdata/basic/docker-compose.basic-externalservice.yml
@@ -1,0 +1,34 @@
+services:
+  basic1:
+    build:
+      context: internal/testdata/basic/docker
+      dockerfile: basic.dockerfile
+    labels:
+      lagoon.type: basic
+      lagoon.service.port: 8080
+    ports:
+      - '8080'
+  basic2:
+    build:
+      context: internal/testdata/basic/docker
+      dockerfile: basic.dockerfile
+    labels:
+      lagoon.type: external
+      # this service would be classed as an internal cluster externalname, the port to access it would be the same port
+      # as it would if it was running in the environment
+      lagoon.external.service: '{"name":"basic","project":"other-project","environment":"main"}'
+    ports:
+      # this is ignored by lagoon when the type is external
+      - '8181'
+  basic3:
+    build:
+      context: internal/testdata/basic/docker
+      dockerfile: basic.dockerfile
+    labels:
+      lagoon.type: external
+      # when defining an external service domain, the port may not be the same as if it was an internal cluster externalname
+      # the user would have to know more about the application and the external domain endpoint to know which port can be used
+      lagoon.external.service: '{"domain":"some-domain.example.com"}'
+    ports:
+      # this is ignored by lagoon when the type is external
+      - '8282' 

--- a/internal/testdata/basic/lagoon.externalservice.yml
+++ b/internal/testdata/basic/lagoon.externalservice.yml
@@ -1,0 +1,61 @@
+docker-compose-yaml: internal/testdata/basic/docker-compose.basic-externalservice.yml
+
+environment_variables:
+  git_sha: "true"
+
+environments:
+  main:
+    routes:
+      - node:
+          - example.com
+  stage:
+    routes:
+      - node:
+          - example.com
+    # this is an example of defining a simple network policy directly on an environment
+    network-policies:
+      # the name of the service you want to allow connections to
+      - service: basic1
+        organizations: 
+        # this allows anything in this organization
+        - name: example-org1
+
+# network-policies allow you to restrict which organizations, projects, or environments, can access a specific service
+# in the environment this policy is created in
+# network-policies only work if the environments are in the same cluster
+# this example is only to show how it could be used to create complex network policies if required
+# default network policies are to reject all ingress traffic from other lagoon environments
+# so all network policies are configured to allow from other environments only
+# there are some ways to exclude some traffic by setting policies that use exclude-projects or exclude-environments within
+# network-policies can also be defined under an environment in the environments section
+network-policies:
+  # the name of the service you want to allow connections to
+  - service: basic1
+    organizations: 
+    # this allows anything in this organization
+    - name: example-org1
+    # this allows anything in this organization from a production environment only
+    - name: example-org2
+      environment-type: production
+    # this allows anything in this organization except projects listed
+    - name: example-org3
+      exclude-projects:
+      - name: projecta
+      - name: projectb
+    projects:
+    # this allows anything from this projects main environment
+    - name: my-project1
+      environment: main
+    # this allows anything from this projects production environment
+    - name: my-project2
+      environment-type: production
+    # this allows anything from this project excluding specific environments
+    - name: my-project3
+      exclude-environments:
+      # these are the name of the environment from lagoon, not the escaped/safe versions used by machines
+      # the build-tool will handle conversions to the machine version as required
+      - name: feature/branch
+      - name: feature/environment-with-really-really-really-really-really-really-long-branch-name-that-will-truncate
+    # this allows anything from this project except pullrequest environment
+    - name: my-project4
+      exclude-pullrequests: true

--- a/internal/testdata/basic/service-templates/test-basic-external-service-environment/deployment-basic1.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-external-service-environment/deployment-basic1.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    lagoon.sh/branch: stage
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic1
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: basic
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: stage
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic1
+    lagoon.sh/service-type: basic
+    lagoon.sh/template: basic-0.1.0
+  name: basic1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: basic1
+      app.kubernetes.io/name: basic
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        lagoon.sh/branch: stage
+        lagoon.sh/configMapSha: abcdefg1234567890
+        lagoon.sh/version: v2.7.x
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: basic1
+        app.kubernetes.io/managed-by: build-deploy-tool
+        app.kubernetes.io/name: basic
+        lagoon.sh/buildType: branch
+        lagoon.sh/environment: stage
+        lagoon.sh/environmentType: production
+        lagoon.sh/project: example-project
+        lagoon.sh/service: basic1
+        lagoon.sh/service-type: basic
+        lagoon.sh/template: basic-0.1.0
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - env:
+        - name: LAGOON_GIT_SHA
+          value: abcdefg123456
+        - name: CRONJOBS
+        - name: SERVICE_NAME
+          value: basic1
+        envFrom:
+        - secretRef:
+            name: lagoon-platform-env
+        - secretRef:
+            name: lagoon-env
+        image: harbor.example/example-project/stage/basic1@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8
+        imagePullPolicy: Always
+        livenessProbe:
+          initialDelaySeconds: 60
+          tcpSocket:
+            port: 8080
+          timeoutSeconds: 10
+        name: basic
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        readinessProbe:
+          initialDelaySeconds: 1
+          tcpSocket:
+            port: 8080
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext: {}
+      enableServiceLinks: false
+      imagePullSecrets:
+      - name: lagoon-internal-registry-secret
+      priorityClassName: lagoon-priority-production
+status: {}

--- a/internal/testdata/basic/service-templates/test-basic-external-service-environment/networkpolicy-basic1.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-external-service-environment/networkpolicy-basic1.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations:
+    lagoon.sh/branch: stage
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: service-network-policy
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: service-network-policy
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: stage
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic1
+    lagoon.sh/service-type: network-policy
+    lagoon.sh/template: service-network-policy-0.1.0
+  name: basic1
+spec:
+  ingress:
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: organization.lagoon.sh/name
+          operator: In
+          values:
+          - example-org1
+  podSelector:
+    matchLabels:
+      lagoon.sh/service: basic1

--- a/internal/testdata/basic/service-templates/test-basic-external-service-environment/service-basic1.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-external-service-environment/service-basic1.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: stage
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic1
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: basic
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: stage
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic1
+    lagoon.sh/service-type: basic
+    lagoon.sh/template: basic-0.1.0
+  name: basic1
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: http
+  selector:
+    app.kubernetes.io/instance: basic1
+    app.kubernetes.io/name: basic
+status:
+  loadBalancer: {}

--- a/internal/testdata/basic/service-templates/test-basic-external-service-environment/service-basic2.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-external-service-environment/service-basic2.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: stage
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic2
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: external
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: stage
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic2
+    lagoon.sh/service-type: external
+    lagoon.sh/template: external-0.1.0
+  name: basic2
+spec:
+  externalName: basic.other-project-main.svc.cluster.local
+  type: ExternalName
+status:
+  loadBalancer: {}

--- a/internal/testdata/basic/service-templates/test-basic-external-service-environment/service-basic3.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-external-service-environment/service-basic3.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: stage
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic3
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: external
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: stage
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic3
+    lagoon.sh/service-type: external
+    lagoon.sh/template: external-0.1.0
+  name: basic3
+spec:
+  externalName: some-domain.example.com
+  type: ExternalName
+status:
+  loadBalancer: {}

--- a/internal/testdata/basic/service-templates/test-basic-external-service/deployment-basic1.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-external-service/deployment-basic1.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic1
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: basic
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic1
+    lagoon.sh/service-type: basic
+    lagoon.sh/template: basic-0.1.0
+  name: basic1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: basic1
+      app.kubernetes.io/name: basic
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        lagoon.sh/branch: main
+        lagoon.sh/configMapSha: abcdefg1234567890
+        lagoon.sh/version: v2.7.x
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: basic1
+        app.kubernetes.io/managed-by: build-deploy-tool
+        app.kubernetes.io/name: basic
+        lagoon.sh/buildType: branch
+        lagoon.sh/environment: main
+        lagoon.sh/environmentType: production
+        lagoon.sh/project: example-project
+        lagoon.sh/service: basic1
+        lagoon.sh/service-type: basic
+        lagoon.sh/template: basic-0.1.0
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - env:
+        - name: LAGOON_GIT_SHA
+          value: abcdefg123456
+        - name: CRONJOBS
+        - name: SERVICE_NAME
+          value: basic1
+        envFrom:
+        - secretRef:
+            name: lagoon-platform-env
+        - secretRef:
+            name: lagoon-env
+        image: harbor.example/example-project/main/basic1@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8
+        imagePullPolicy: Always
+        livenessProbe:
+          initialDelaySeconds: 60
+          tcpSocket:
+            port: 8080
+          timeoutSeconds: 10
+        name: basic
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        readinessProbe:
+          initialDelaySeconds: 1
+          tcpSocket:
+            port: 8080
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext: {}
+      enableServiceLinks: false
+      imagePullSecrets:
+      - name: lagoon-internal-registry-secret
+      priorityClassName: lagoon-priority-production
+status: {}

--- a/internal/testdata/basic/service-templates/test-basic-external-service/networkpolicy-basic1.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-external-service/networkpolicy-basic1.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: service-network-policy
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: service-network-policy
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic1
+    lagoon.sh/service-type: network-policy
+    lagoon.sh/template: service-network-policy-0.1.0
+  name: basic1
+spec:
+  ingress:
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: lagoon.sh/project
+          operator: In
+          values:
+          - my-project1
+        - key: lagoon.sh/environment
+          operator: In
+          values:
+          - main
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: lagoon.sh/project
+          operator: In
+          values:
+          - my-project2
+        - key: lagoon.sh/environmentType
+          operator: In
+          values:
+          - production
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: lagoon.sh/project
+          operator: In
+          values:
+          - my-project3
+        - key: lagoon.sh/environment
+          operator: NotIn
+          values:
+          - feature-branch
+          - feature-environment-with-really-really-rea-cd7d
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: lagoon.sh/project
+          operator: In
+          values:
+          - my-project4
+        - key: lagoon.sh/buildType
+          operator: NotIn
+          values:
+          - pullrequest
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: organization.lagoon.sh/name
+          operator: In
+          values:
+          - example-org1
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: organization.lagoon.sh/name
+          operator: In
+          values:
+          - example-org2
+        - key: lagoon.sh/environmentType
+          operator: In
+          values:
+          - production
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: organization.lagoon.sh/name
+          operator: In
+          values:
+          - example-org3
+        - key: lagoon.sh/project
+          operator: NotIn
+          values:
+          - projecta
+          - projectb
+  podSelector:
+    matchLabels:
+      lagoon.sh/service: basic1

--- a/internal/testdata/basic/service-templates/test-basic-external-service/service-basic1.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-external-service/service-basic1.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic1
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: basic
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic1
+    lagoon.sh/service-type: basic
+    lagoon.sh/template: basic-0.1.0
+  name: basic1
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: http
+  selector:
+    app.kubernetes.io/instance: basic1
+    app.kubernetes.io/name: basic
+status:
+  loadBalancer: {}

--- a/internal/testdata/basic/service-templates/test-basic-external-service/service-basic2.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-external-service/service-basic2.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic2
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: external
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic2
+    lagoon.sh/service-type: external
+    lagoon.sh/template: external-0.1.0
+  name: basic2
+spec:
+  externalName: basic.other-project-main.svc.cluster.local
+  type: ExternalName
+status:
+  loadBalancer: {}

--- a/internal/testdata/basic/service-templates/test-basic-external-service/service-basic3.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-external-service/service-basic3.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic3
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: external
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic3
+    lagoon.sh/service-type: external
+    lagoon.sh/template: external-0.1.0
+  name: basic3
+spec:
+  externalName: some-domain.example.com
+  type: ExternalName
+status:
+  loadBalancer: {}

--- a/legacy/build-deploy-docker-compose.sh
+++ b/legacy/build-deploy-docker-compose.sh
@@ -1597,7 +1597,7 @@ do
     fi
   done
 
-  if [[ $SERVICE_TYPE == *"-dbaas" ]]; then
+  if [[ $SERVICE_TYPE == *"-dbaas" ]] || [[ "$SERVICE_TYPE" == "external" ]]; then
     echo "nothing to monitor for $SERVICE_TYPE"
   else
     . /kubectl-build-deploy/scripts/exec-monitor-deploy.sh


### PR DESCRIPTION
# Description

This introduces a new service type called `external`. When defined, this type won't provision a deployment with a running container, instead it will create a service with an `ExternalName` record that resolves to the provided environment, or specific domain record.

Additionally, network policy support has been added to `.lagoon.yml` to allow for defining which organization(s), project(s), or environment(s) are able to access a service in the defined environment. By default all Lagoon environments are locked down so that no other environment can access them. These policies are used to grant access.

By combining these two features, users can deploy a service in one environment and apply a network policy that permits access from other environments. In another environment, they can then configure an external service type to point to the shared service.

One caveat is that this communication is done internally within a cluster, so this can only work if all workloads are on the same cluster. Using the `domain` field in an external service could potentially be used for cross cluster, but this domain would need to be able to be resolved, and reachable in some way. It may not cover all use cases, and may not work in all scenarios.

# Usage
## External Service Type
Defining an external service type is done in the docker compose file. An example of this is as follows
```yaml
services:
  myservice:
    image: ...
    labels:
      lagoon.type: external
      lagoon.external.service: '{"name":"basic","project":"other-project","environment":"main"}'
```
> [!IMPORTANT]
> Other options like image, or build context will be ignored by Lagoon. They may need to be defined for local development to work, but if you don't need the service locally, you could look at using [profiles](https://docs.docker.com/compose/how-tos/profiles/) to prevent them from starting locally.

Breaking this down, we have defined a service called `myservice`, and the `lagoon.type` label is set to `external`. This tells Lagoon to check the `lagoon.external.service` label for where to configure this service to point to. This data is a JSON representation of the following:

* `name` (required) - The name of the service in the other environment you want to communicate with
* `project` (required) - The name of the project that the service exists in
* `environment` (required) - The name of the environment as it is in Lagoon (eg, main, feature/branch, pr-123), not the namespace or truncated safe name.
* `domain` (optional) - The domain record to use. If this is defined, the other 3 fields are ignored.

> [!IMPORTANT]
> When referencing an external service from another project or environment, you need to ensure you use the correct port, which will be the port that is exposed on the service. This is generally the port that has been defined in the docker-compose file for the service you're wanting to reference. Eg, if an `nginx` service exposes port `8080`, this is the port you'll need to use.

## Network Policies
Using network policies allows a user to define which `organizations` and/or `projects` can access a service in the environment.

Using the following options, a user can grant all projects from an organization, or using other fields reduce the scope. For example, limiting only to production environments, or excluding certain projects.
```yaml
network-policies:
- service: myservice
  organizations:
  # this allows any environment from any project in example-org1 to access myservice
  - name: example-org1
  # this allows only production environments from any project in example-org1 to access myservice
  - name: example-org2
    environment-type: production
  # this allows any environment from any project except project-a in example-org1 to access myservice
  - name: example-org3
    exclude-projects:
      - name: project-a
```

If allowing an organization is too much, a user can also allow specific projects, environments, environment types, or exclude environments, or exclude pullrequest environments.
```yaml
network-policies:
- service: myservice
  projects: 
  # this allows any environment from example-project1 to access myservice
  - name: example-project1
  # this allows only the main environment from example-project2 to access myservice
  - name: example-project2
    environment: main
  # this allows only the production environment from example-project3 to access myservice
  - name: example-project3
    environment-type: production
  # this allows any environment except feature/develop from example-project4 to access myservice
  - name: example-project4
    exclude-environments:
    - name: feature/develop
  # this allows any environment except pullrequest environments from example-project5 to access myservice
  - name: example-project5
    exclude-pullrequests: true
```

> [!IMPORTANT]  
> It is possible to define a policy that only allows certain environments in the organizations section (for example only production environments). Then by defining a project policy in the projects section, you can selectively allow other environments to access it from more specific project override, for example allowing more than production from one or more projects that you want to be able to also access that service.
>
> This also means that some policies may not be possible to, so a user may have to define everything under projects to be more specific, rather than using the organization section.

### Defining policies
Network policies can be defined in three ways in a `.lagoon.yml` file. 

* At the root of the `.lagoon.yml` file under `network-policies`
* Under an environment under `network-policies`, similar to how routes would be defined. If defined here, the root is ignored
* Under an environment, but within a polysite setup. If defined here, others are ignored.

#### At the root
```yaml
network-policies:
- service: myservice
  organizations: 
  - name: example-org
```

#### Under a environment
```yaml
environments:
  main:
    network-policies:
    - service: myservice
      organizations: 
      - name: example-org
```

#### Under a polysite environment
```yaml
example-project:
  environments:
    main:
      network-policies:
      - service: myservice
        organizations: 
        - name: example-org
```