### PR TITLE
fix: multiline cronjob validation

### DIFF
--- a/cmd/validate_lagoonyml.go
+++ b/cmd/validate_lagoonyml.go
@@ -85,11 +85,9 @@ func init() {
 // ValidateCronjob returns an error if the command for the cronjob has any
 // newlines, and nil otherwise.
 func ValidateCronjob(c *lagoon.Cronjob) error {
-	command := strings.TrimSpace(c.Command)
-
-	if strings.Contains(command, "\n") {
+	if strings.Contains(strings.TrimSpace(c.Command), "\n") || strings.HasSuffix(c.Command, "\n") {
 		return fmt.Errorf("invalid cronjob, multiline commands are not supported: %q",
-			command)
+			c.Command)
 	}
 
 	return nil

--- a/internal/testdata/validate-lagoon-yml/cronjobs/multiline-cronjobs.lagoon.yml
+++ b/internal/testdata/validate-lagoon-yml/cronjobs/multiline-cronjobs.lagoon.yml
@@ -32,17 +32,26 @@ environments:
           multiline
           command
 
-      - name: block scalar folded clipped
+      - name: block scalar folded clipped blank newline
         command: >
           multiline
 
           command
 
-      - name: block scalar folded stripped
+      - name: block scalar folded stripped blank newline
         command: >-
           multiline
 
           command
+
+      - name: block scalar folded clipped double
+        command: >
+          singleline
+          command
+
+      - name: block scalar folded clipped single
+        command: >
+          singleline command
 
       - name: block scalar folded keep
         command: >+

--- a/internal/testdata/validate-lagoon-yml/cronjobs/singleline-cronjobs.lagoon.yml
+++ b/internal/testdata/validate-lagoon-yml/cronjobs/singleline-cronjobs.lagoon.yml
@@ -28,13 +28,6 @@ environments:
         command: |-
           singleline command
 
-      - name: block scalar folded clipped 1
-        command: >
-          singleline
-          command
-      - name: block scalar folded clipped 2
-        command: >
-          singleline command
       - name: block scalar folded stripped 1
         command: >-
           singleline


### PR DESCRIPTION
# Problem

The current `ValidateCronjob` func checks for `\n` characters in the command, but does so after trimming the leading and trailing whitespace characters.

https://github.com/uselagoon/build-deploy-tool/blob/3d00d84607cda413c304cbf2183312c472ae7927/cmd/validate_lagoonyml.go#L87-L96

This does not catch commands that end in a `\n` and will fail the cronjob with the error:  `syntax error: unterminated quoted string`

Checking crontab shows the issue:

```
> cat /lagoon/crontabs/crontab 
* * * * * flock -n /tmp/cron.lock/xxxxxx 'command
'
```

This isn't caught because the following test cases are currently allowed as apparent single lines, but they are invalid due to the trailing \n at the end inserted by the clip:

https://github.com/uselagoon/build-deploy-tool/blob/3d00d84607cda413c304cbf2183312c472ae7927/internal/testdata/validate-lagoon-yml/cronjobs/singleline-cronjobs.lagoon.yml#L31-L37