### PR TITLE
Better debugging output for task scaling

### DIFF
--- a/internal/lagoon/tasks.go
+++ b/internal/lagoon/tasks.go
@@ -285,7 +285,7 @@ func ExecTaskInPod(
 	if debug {
 		fmt.Printf("Task '%v' executed in pod %v \n", task.Name, pod.Name)
 		if numIterations > 1 {
-			fmt.Printf("Pod scaling function called %d times before executing task\n", (numIterations - 1))
+			fmt.Printf("Pod scaling function called %d time(s) before executing task\n", (numIterations - 1))
 		}
 		if task.ScaleWaitTime > 0 {
 			fmt.Printf("Waited %d seconds before executing task\n", task.ScaleWaitTime)

--- a/internal/lagoon/tasks.go
+++ b/internal/lagoon/tasks.go
@@ -285,7 +285,7 @@ func ExecTaskInPod(
 	if debug {
 		fmt.Printf("Task '%v' executed in pod %v \n", task.Name, pod.Name)
 		if numIterations > 1 {
-			fmt.Printf("Scaled up pods to %d replicas before executing task\n", numIterations)
+			fmt.Printf("Pod scaling function called %d times before executing task\n", (numIterations - 1))
 		}
 		if task.ScaleWaitTime > 0 {
 			fmt.Printf("Waited %d seconds before executing task\n", task.ScaleWaitTime)


### PR DESCRIPTION
The task scaling debug output contains a logic error in the output, showing `n` instead of `n - 1`

<img width="512" height="351" alt="image" src="https://github.com/user-attachments/assets/82cb6da3-b9cc-4e81-8d52-848342224652" />
