### PR TITLE
fix: print lagoonyaml validation completion before dockercompose validation

### DIFF
--- a/legacy/build-deploy-docker-compose.sh
+++ b/legacy/build-deploy-docker-compose.sh
@@ -282,6 +282,20 @@ https://docs.lagoon.sh/using-lagoon-the-basics/lagoon-yml/
   exit 1
 fi
 
+# Validate .lagoon.yml only, no overrides. lagoon-linter still has checks that
+# aren't in build-deploy-tool.
+if ! lagoon-linter; then
+	echo "${LAGOON_FEATURE_FLAG_DEFAULT_DOCUMENTATION_URL}/lagoon/using-lagoon-the-basics/lagoon-yml#restrictions describes some possible reasons for this build failure."
+	echo "If you require assistance to fix this error, please contact support."
+	exit 1
+else
+	echo "lagoon-linter found no issues with the .lagoon.yml file"
+fi
+
+currentStepEnd="$(date +"%Y-%m-%d %H:%M:%S")"
+finalizeBuildStep "${buildStartTime}" "${previousStepEnd}" "${currentStepEnd}" "${NAMESPACE}" "lagoonYmlValidation" ".lagoon.yml Validation" "false"
+previousStepEnd=${currentStepEnd}
+
 # The attempt to valid the `docker-compose.yaml` file
 beginBuildStep "Docker Compose Validation" "dockerComposeValidation"
 
@@ -412,16 +426,6 @@ else
 fi
 set -e
 
-# Validate .lagoon.yml only, no overrides. lagoon-linter still has checks that
-# aren't in build-deploy-tool.
-if ! lagoon-linter; then
-	echo "${LAGOON_FEATURE_FLAG_DEFAULT_DOCUMENTATION_URL}/lagoon/using-lagoon-the-basics/lagoon-yml#restrictions describes some possible reasons for this build failure."
-	echo "If you require assistance to fix this error, please contact support."
-	exit 1
-else
-	echo "lagoon-linter found no issues with the .lagoon.yml file"
-fi
-
 ##################
 # build deploy-tool can collect this value now from the lagoon.yml file
 # this means further use of `LAGOON_GIT_SHA` can eventually be
@@ -442,9 +446,6 @@ else
 fi
 ##################
 
-currentStepEnd="$(date +"%Y-%m-%d %H:%M:%S")"
-finalizeBuildStep "${buildStartTime}" "${previousStepEnd}" "${currentStepEnd}" "${NAMESPACE}" "lagoonYmlValidation" ".lagoon.yml Validation" "false"
-previousStepEnd=${currentStepEnd}
 beginBuildStep "Configure Variables" "configuringVariables"
 
 # Load all Services that are defined


### PR DESCRIPTION
Fixes where the lagoon yaml validation completion step prints in the log output to prevent it combining with the docker-compose validation step.

The issue is that the `STEP .lagoon.yml Validation: Completed` was being printed after the `BEGIN Docker Compose Validation` stage, when it should be before.

An example of the incorrect log is below:
```
##############################################
BEGIN .lagoon.yml Validation
##############################################
Updating lagoon-yaml configmap with a pre-deploy version of the .lagoon.yml file
configmap/lagoon-yaml configured
##############################################
BEGIN Docker Compose Validation
##############################################
Updating docker-compose-yaml configmap with a pre-deploy version of the docker-compose.yml file
configmap/docker-compose-yaml configured
##############################################
STEP Docker Compose Validation: Completed at 2025-09-10 01:18:14 (UTC) Duration 00:00:02 Elapsed 00:00:03
##############################################
lagoon-linter found no issues with the .lagoon.yml file
##############################################
STEP .lagoon.yml Validation: Completed at 2025-09-10 01:18:15 (UTC) Duration 00:00:01 Elapsed 00:00:04
##############################################
```

And it should look roughly like this, where `STEP .lagoon.yml Validation: Completed` is printed before the `BEGIN Docker Compose Validation`
```
##############################################
BEGIN .lagoon.yml Validation
##############################################
Updating lagoon-yaml configmap with a pre-deploy version of the .lagoon.yml file
configmap/lagoon-yaml configured
lagoon-linter found no issues with the .lagoon.yml file
##############################################
STEP .lagoon.yml Validation: Completed at 2025-09-10 01:18:13 (UTC) Duration 00:00:01 Elapsed 00:00:04
##############################################
##############################################
BEGIN Docker Compose Validation
##############################################
Updating docker-compose-yaml configmap with a pre-deploy version of the docker-compose.yml file
configmap/docker-compose-yaml configured
##############################################
STEP Docker Compose Validation: Completed at 2025-09-10 01:18:14 (UTC) Duration 00:00:02 Elapsed 00:00:03
##############################################
```