### PR TITLE
fix: add slashes to backup commands

### DIFF
--- a/internal/templating/template_prebackuppod.go
+++ b/internal/templating/template_prebackuppod.go
@@ -330,36 +330,36 @@ func RemoveCreationTimestamp(a []byte) ([]byte, error) {
 	return yaml.Marshal(tmpMap)
 }
 
-var mariadbBackupCommand = `/bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then
-BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1);
-fi &&
-dump=$(mktemp)
-&& mysqldump --max-allowed-packet=1G --events --routines --quick
---add-locks --no-autocommit --single-transaction --no-create-db
---no-data --no-tablespaces
--h $BACKUP_DB_HOST
--u $BACKUP_DB_USERNAME
--p$BACKUP_DB_PASSWORD
-$BACKUP_DB_DATABASE
-> $dump
-&& mysqldump --max-allowed-packet=1G --events --routines --quick
---add-locks --no-autocommit --single-transaction --no-create-db
---ignore-table=$BACKUP_DB_DATABASE.watchdog
---no-create-info --no-tablespaces --skip-triggers
--h $BACKUP_DB_HOST
--u $BACKUP_DB_USERNAME
--p$BACKUP_DB_PASSWORD
-$BACKUP_DB_DATABASE
->> $dump
+var mariadbBackupCommand = `/bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then \
+BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1); \
+fi && \
+dump=$(mktemp) \
+&& mysqldump --max-allowed-packet=1G --events --routines --quick \
+--add-locks --no-autocommit --single-transaction --no-create-db \
+--no-data --no-tablespaces \
+-h $BACKUP_DB_HOST \
+-u $BACKUP_DB_USERNAME \
+-p$BACKUP_DB_PASSWORD \
+$BACKUP_DB_DATABASE \
+> $dump \
+&& mysqldump --max-allowed-packet=1G --events --routines --quick \
+--add-locks --no-autocommit --single-transaction --no-create-db \
+--ignore-table=$BACKUP_DB_DATABASE.watchdog \
+--no-create-info --no-tablespaces --skip-triggers \
+-h $BACKUP_DB_HOST \
+-u $BACKUP_DB_USERNAME \
+-p$BACKUP_DB_PASSWORD \
+$BACKUP_DB_DATABASE \
+>> $dump \
 && cat $dump && rm $dump"`
 
-var postgresBackupCommand = `/bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then
-BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1);
-fi && PGPASSWORD=$BACKUP_DB_PASSWORD pg_dump
---host=$BACKUP_DB_HOST
---port=$BACKUP_DB_PORT
---dbname=$BACKUP_DB_DATABASE
---username=$BACKUP_DB_USERNAME
+var postgresBackupCommand = `/bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then \
+BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1); \
+fi && PGPASSWORD=$BACKUP_DB_PASSWORD pg_dump \
+--host=$BACKUP_DB_HOST \
+--port=$BACKUP_DB_PORT \
+--dbname=$BACKUP_DB_DATABASE \
+--username=$BACKUP_DB_USERNAME \
 --format=t -w"`
 
 var mongoBackupCommand = `/bin/sh -c "dump=$(mktemp) && mongodump \

--- a/internal/templating/test-resources/backups/result-prebackuppod1.yaml
+++ b/internal/templating/test-resources/backups/result-prebackuppod1.yaml
@@ -20,27 +20,27 @@ metadata:
   name: mariadb-database-prebackuppod
 spec:
   backupCommand: |-
-    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then
-    BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1);
-    fi &&
-    dump=$(mktemp)
-    && mysqldump --max-allowed-packet=1G --events --routines --quick
-    --add-locks --no-autocommit --single-transaction --no-create-db
-    --no-data --no-tablespaces
-    -h $BACKUP_DB_HOST
-    -u $BACKUP_DB_USERNAME
-    -p$BACKUP_DB_PASSWORD
-    $BACKUP_DB_DATABASE
-    > $dump
-    && mysqldump --max-allowed-packet=1G --events --routines --quick
-    --add-locks --no-autocommit --single-transaction --no-create-db
-    --ignore-table=$BACKUP_DB_DATABASE.watchdog
-    --no-create-info --no-tablespaces --skip-triggers
-    -h $BACKUP_DB_HOST
-    -u $BACKUP_DB_USERNAME
-    -p$BACKUP_DB_PASSWORD
-    $BACKUP_DB_DATABASE
-    >> $dump
+    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then \
+    BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1); \
+    fi && \
+    dump=$(mktemp) \
+    && mysqldump --max-allowed-packet=1G --events --routines --quick \
+    --add-locks --no-autocommit --single-transaction --no-create-db \
+    --no-data --no-tablespaces \
+    -h $BACKUP_DB_HOST \
+    -u $BACKUP_DB_USERNAME \
+    -p$BACKUP_DB_PASSWORD \
+    $BACKUP_DB_DATABASE \
+    > $dump \
+    && mysqldump --max-allowed-packet=1G --events --routines --quick \
+    --add-locks --no-autocommit --single-transaction --no-create-db \
+    --ignore-table=$BACKUP_DB_DATABASE.watchdog \
+    --no-create-info --no-tablespaces --skip-triggers \
+    -h $BACKUP_DB_HOST \
+    -u $BACKUP_DB_USERNAME \
+    -p$BACKUP_DB_PASSWORD \
+    $BACKUP_DB_DATABASE \
+    >> $dump \
     && cat $dump && rm $dump"
   fileExtension: .mariadb-database.sql
   pod:

--- a/internal/templating/test-resources/backups/result-prebackuppod2.yaml
+++ b/internal/templating/test-resources/backups/result-prebackuppod2.yaml
@@ -20,13 +20,13 @@ metadata:
   name: postgres-database-prebackuppod
 spec:
   backupCommand: |-
-    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then
-    BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1);
-    fi && PGPASSWORD=$BACKUP_DB_PASSWORD pg_dump
-    --host=$BACKUP_DB_HOST
-    --port=$BACKUP_DB_PORT
-    --dbname=$BACKUP_DB_DATABASE
-    --username=$BACKUP_DB_USERNAME
+    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then \
+    BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1); \
+    fi && PGPASSWORD=$BACKUP_DB_PASSWORD pg_dump \
+    --host=$BACKUP_DB_HOST \
+    --port=$BACKUP_DB_PORT \
+    --dbname=$BACKUP_DB_DATABASE \
+    --username=$BACKUP_DB_USERNAME \
     --format=t -w"
   fileExtension: .postgres-database.tar
   pod:

--- a/internal/templating/test-resources/backups/result-prebackuppod4.yaml
+++ b/internal/templating/test-resources/backups/result-prebackuppod4.yaml
@@ -20,27 +20,27 @@ metadata:
   name: mariadb-database-prebackuppod
 spec:
   backupCommand: |-
-    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then
-    BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1);
-    fi &&
-    dump=$(mktemp)
-    && mysqldump --max-allowed-packet=1G --events --routines --quick
-    --add-locks --no-autocommit --single-transaction --no-create-db
-    --no-data --no-tablespaces
-    -h $BACKUP_DB_HOST
-    -u $BACKUP_DB_USERNAME
-    -p$BACKUP_DB_PASSWORD
-    $BACKUP_DB_DATABASE
-    > $dump
-    && mysqldump --max-allowed-packet=1G --events --routines --quick
-    --add-locks --no-autocommit --single-transaction --no-create-db
-    --ignore-table=$BACKUP_DB_DATABASE.watchdog
-    --no-create-info --no-tablespaces --skip-triggers
-    -h $BACKUP_DB_HOST
-    -u $BACKUP_DB_USERNAME
-    -p$BACKUP_DB_PASSWORD
-    $BACKUP_DB_DATABASE
-    >> $dump
+    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then \
+    BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1); \
+    fi && \
+    dump=$(mktemp) \
+    && mysqldump --max-allowed-packet=1G --events --routines --quick \
+    --add-locks --no-autocommit --single-transaction --no-create-db \
+    --no-data --no-tablespaces \
+    -h $BACKUP_DB_HOST \
+    -u $BACKUP_DB_USERNAME \
+    -p$BACKUP_DB_PASSWORD \
+    $BACKUP_DB_DATABASE \
+    > $dump \
+    && mysqldump --max-allowed-packet=1G --events --routines --quick \
+    --add-locks --no-autocommit --single-transaction --no-create-db \
+    --ignore-table=$BACKUP_DB_DATABASE.watchdog \
+    --no-create-info --no-tablespaces --skip-triggers \
+    -h $BACKUP_DB_HOST \
+    -u $BACKUP_DB_USERNAME \
+    -p$BACKUP_DB_PASSWORD \
+    $BACKUP_DB_DATABASE \
+    >> $dump \
     && cat $dump && rm $dump"
   fileExtension: .mariadb-database.sql
   pod:

--- a/internal/templating/test-resources/backups/result-prebackuppod5.yaml
+++ b/internal/templating/test-resources/backups/result-prebackuppod5.yaml
@@ -20,27 +20,27 @@ metadata:
   name: mariadb-database-prebackuppod
 spec:
   backupCommand: |-
-    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then
-    BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1);
-    fi &&
-    dump=$(mktemp)
-    && mysqldump --max-allowed-packet=1G --events --routines --quick
-    --add-locks --no-autocommit --single-transaction --no-create-db
-    --no-data --no-tablespaces
-    -h $BACKUP_DB_HOST
-    -u $BACKUP_DB_USERNAME
-    -p$BACKUP_DB_PASSWORD
-    $BACKUP_DB_DATABASE
-    > $dump
-    && mysqldump --max-allowed-packet=1G --events --routines --quick
-    --add-locks --no-autocommit --single-transaction --no-create-db
-    --ignore-table=$BACKUP_DB_DATABASE.watchdog
-    --no-create-info --no-tablespaces --skip-triggers
-    -h $BACKUP_DB_HOST
-    -u $BACKUP_DB_USERNAME
-    -p$BACKUP_DB_PASSWORD
-    $BACKUP_DB_DATABASE
-    >> $dump
+    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then \
+    BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1); \
+    fi && \
+    dump=$(mktemp) \
+    && mysqldump --max-allowed-packet=1G --events --routines --quick \
+    --add-locks --no-autocommit --single-transaction --no-create-db \
+    --no-data --no-tablespaces \
+    -h $BACKUP_DB_HOST \
+    -u $BACKUP_DB_USERNAME \
+    -p$BACKUP_DB_PASSWORD \
+    $BACKUP_DB_DATABASE \
+    > $dump \
+    && mysqldump --max-allowed-packet=1G --events --routines --quick \
+    --add-locks --no-autocommit --single-transaction --no-create-db \
+    --ignore-table=$BACKUP_DB_DATABASE.watchdog \
+    --no-create-info --no-tablespaces --skip-triggers \
+    -h $BACKUP_DB_HOST \
+    -u $BACKUP_DB_USERNAME \
+    -p$BACKUP_DB_PASSWORD \
+    $BACKUP_DB_DATABASE \
+    >> $dump \
     && cat $dump && rm $dump"
   fileExtension: .mariadb-database.sql
   pod:
@@ -102,27 +102,27 @@ metadata:
   name: mariadb-prebackuppod
 spec:
   backupCommand: |-
-    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then
-    BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1);
-    fi &&
-    dump=$(mktemp)
-    && mysqldump --max-allowed-packet=1G --events --routines --quick
-    --add-locks --no-autocommit --single-transaction --no-create-db
-    --no-data --no-tablespaces
-    -h $BACKUP_DB_HOST
-    -u $BACKUP_DB_USERNAME
-    -p$BACKUP_DB_PASSWORD
-    $BACKUP_DB_DATABASE
-    > $dump
-    && mysqldump --max-allowed-packet=1G --events --routines --quick
-    --add-locks --no-autocommit --single-transaction --no-create-db
-    --ignore-table=$BACKUP_DB_DATABASE.watchdog
-    --no-create-info --no-tablespaces --skip-triggers
-    -h $BACKUP_DB_HOST
-    -u $BACKUP_DB_USERNAME
-    -p$BACKUP_DB_PASSWORD
-    $BACKUP_DB_DATABASE
-    >> $dump
+    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then \
+    BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1); \
+    fi && \
+    dump=$(mktemp) \
+    && mysqldump --max-allowed-packet=1G --events --routines --quick \
+    --add-locks --no-autocommit --single-transaction --no-create-db \
+    --no-data --no-tablespaces \
+    -h $BACKUP_DB_HOST \
+    -u $BACKUP_DB_USERNAME \
+    -p$BACKUP_DB_PASSWORD \
+    $BACKUP_DB_DATABASE \
+    > $dump \
+    && mysqldump --max-allowed-packet=1G --events --routines --quick \
+    --add-locks --no-autocommit --single-transaction --no-create-db \
+    --ignore-table=$BACKUP_DB_DATABASE.watchdog \
+    --no-create-info --no-tablespaces --skip-triggers \
+    -h $BACKUP_DB_HOST \
+    -u $BACKUP_DB_USERNAME \
+    -p$BACKUP_DB_PASSWORD \
+    $BACKUP_DB_DATABASE \
+    >> $dump \
     && cat $dump && rm $dump"
   fileExtension: .mariadb.sql
   pod:

--- a/internal/testdata/complex/backup-templates/backup-1/prebackuppods.yaml
+++ b/internal/testdata/complex/backup-templates/backup-1/prebackuppods.yaml
@@ -20,27 +20,27 @@ metadata:
   name: mariadb-prebackuppod
 spec:
   backupCommand: |-
-    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then
-    BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1);
-    fi &&
-    dump=$(mktemp)
-    && mysqldump --max-allowed-packet=1G --events --routines --quick
-    --add-locks --no-autocommit --single-transaction --no-create-db
-    --no-data --no-tablespaces
-    -h $BACKUP_DB_HOST
-    -u $BACKUP_DB_USERNAME
-    -p$BACKUP_DB_PASSWORD
-    $BACKUP_DB_DATABASE
-    > $dump
-    && mysqldump --max-allowed-packet=1G --events --routines --quick
-    --add-locks --no-autocommit --single-transaction --no-create-db
-    --ignore-table=$BACKUP_DB_DATABASE.watchdog
-    --no-create-info --no-tablespaces --skip-triggers
-    -h $BACKUP_DB_HOST
-    -u $BACKUP_DB_USERNAME
-    -p$BACKUP_DB_PASSWORD
-    $BACKUP_DB_DATABASE
-    >> $dump
+    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then \
+    BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1); \
+    fi && \
+    dump=$(mktemp) \
+    && mysqldump --max-allowed-packet=1G --events --routines --quick \
+    --add-locks --no-autocommit --single-transaction --no-create-db \
+    --no-data --no-tablespaces \
+    -h $BACKUP_DB_HOST \
+    -u $BACKUP_DB_USERNAME \
+    -p$BACKUP_DB_PASSWORD \
+    $BACKUP_DB_DATABASE \
+    > $dump \
+    && mysqldump --max-allowed-packet=1G --events --routines --quick \
+    --add-locks --no-autocommit --single-transaction --no-create-db \
+    --ignore-table=$BACKUP_DB_DATABASE.watchdog \
+    --no-create-info --no-tablespaces --skip-triggers \
+    -h $BACKUP_DB_HOST \
+    -u $BACKUP_DB_USERNAME \
+    -p$BACKUP_DB_PASSWORD \
+    $BACKUP_DB_DATABASE \
+    >> $dump \
     && cat $dump && rm $dump"
   fileExtension: .mariadb.sql
   pod:

--- a/internal/testdata/complex/backup-templates/backup-2/prebackuppods.yaml
+++ b/internal/testdata/complex/backup-templates/backup-2/prebackuppods.yaml
@@ -20,27 +20,27 @@ metadata:
   name: mariadb-prebackuppod
 spec:
   backupCommand: |-
-    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then
-    BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1);
-    fi &&
-    dump=$(mktemp)
-    && mysqldump --max-allowed-packet=1G --events --routines --quick
-    --add-locks --no-autocommit --single-transaction --no-create-db
-    --no-data --no-tablespaces
-    -h $BACKUP_DB_HOST
-    -u $BACKUP_DB_USERNAME
-    -p$BACKUP_DB_PASSWORD
-    $BACKUP_DB_DATABASE
-    > $dump
-    && mysqldump --max-allowed-packet=1G --events --routines --quick
-    --add-locks --no-autocommit --single-transaction --no-create-db
-    --ignore-table=$BACKUP_DB_DATABASE.watchdog
-    --no-create-info --no-tablespaces --skip-triggers
-    -h $BACKUP_DB_HOST
-    -u $BACKUP_DB_USERNAME
-    -p$BACKUP_DB_PASSWORD
-    $BACKUP_DB_DATABASE
-    >> $dump
+    /bin/sh -c "if [ ! -z $BACKUP_DB_READREPLICA_HOSTS ]; then \
+    BACKUP_DB_HOST=$(echo $BACKUP_DB_READREPLICA_HOSTS | cut -d ',' -f1); \
+    fi && \
+    dump=$(mktemp) \
+    && mysqldump --max-allowed-packet=1G --events --routines --quick \
+    --add-locks --no-autocommit --single-transaction --no-create-db \
+    --no-data --no-tablespaces \
+    -h $BACKUP_DB_HOST \
+    -u $BACKUP_DB_USERNAME \
+    -p$BACKUP_DB_PASSWORD \
+    $BACKUP_DB_DATABASE \
+    > $dump \
+    && mysqldump --max-allowed-packet=1G --events --routines --quick \
+    --add-locks --no-autocommit --single-transaction --no-create-db \
+    --ignore-table=$BACKUP_DB_DATABASE.watchdog \
+    --no-create-info --no-tablespaces --skip-triggers \
+    -h $BACKUP_DB_HOST \
+    -u $BACKUP_DB_USERNAME \
+    -p$BACKUP_DB_PASSWORD \
+    $BACKUP_DB_DATABASE \
+    >> $dump \
     && cat $dump && rm $dump"
   fileExtension: .mariadb.sql
   pod:


### PR DESCRIPTION
This adds slashes to the end of command lines introduced in #451 