### PR TITLE
feat: support for build hook entrypoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,7 @@ RUN architecture=$(case $(uname -m) in x86_64 | amd64) echo "amd64" ;; aarch64 |
 
 RUN mkdir -p /kubectl-build-deploy/git
 RUN mkdir -p /kubectl-build-deploy/lagoon
+RUN mkdir -p /kubectl-build-deploy/hooks
 
 WORKDIR /kubectl-build-deploy/git
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -107,6 +107,7 @@ func init() {
 	rootCmd.AddCommand(identifyCmd)
 	rootCmd.AddCommand(validateCmd)
 	rootCmd.AddCommand(collectCmd)
+	rootCmd.AddCommand(runCmd)
 
 	rootCmd.PersistentFlags().StringP("lagoon-yml", "l", ".lagoon.yml",
 		"The .lagoon.yml file to read")

--- a/cmd/run_hooks.go
+++ b/cmd/run_hooks.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/uselagoon/build-deploy-tool/internal/hooks"
+)
+
+var runCmd = &cobra.Command{
+	Use:     "run",
+	Aliases: []string{"r"},
+	Short:   "Run commands",
+}
+
+var runHookCmd = &cobra.Command{
+	Use:     "hooks",
+	Aliases: []string{"hook", "h"},
+	Short:   "Run build hooks",
+	Long:    "Run build hooks of specific types at entrypoints in a build",
+	Run: func(cmd *cobra.Command, args []string) {
+		hookName, err := cmd.Flags().GetString("hook-name")
+		if err != nil {
+			fmt.Printf("error reading hook-name flag: %v\n", err)
+			os.Exit(1)
+		}
+		hookDir, err := cmd.Flags().GetString("hook-directory")
+		if err != nil {
+			fmt.Printf("error reading hook-directory flag: %v\n", err)
+			os.Exit(1)
+		}
+		dir := fmt.Sprintf("/kubectl-build-deploy/hooks/%s", hookDir)
+		err = hooks.RunHooks(hookName, dir)
+		if err != nil {
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	runCmd.AddCommand(runHookCmd)
+	runHookCmd.Flags().StringP("hook-name", "N", "", "The name of the hooks run")
+	runHookCmd.Flags().StringP("hook-directory", "D", "", "The name of the hook directory to run")
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -1,0 +1,84 @@
+package hooks
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+func RunHooks(hookName, hookDir string) error {
+	if _, err := os.Stat(hookDir); os.IsNotExist(err) {
+		// there are no hooks to run, so just bail
+		return nil
+	}
+	files, err := os.ReadDir(hookDir)
+	if err != nil {
+		// there was an error getting the list of files in the hookdirectory
+		// just bail to prevent issues
+		fmt.Printf("failed to read hook directory: %s", err)
+		return nil
+	}
+
+	hookCount := 0
+	for _, file := range files {
+		if file.IsDir() || !isExecutable(fmt.Sprintf("%s/%s", hookDir, file.Name())) {
+			// skip if directory or not executable
+			continue
+		}
+		hookCount++
+
+		// print the step header for build log parser
+		fmt.Printf("##############################################\nBEGIN %s - %d\n##############################################\n", hookName, hookCount)
+		st := time.Now()
+		binaryPath := filepath.Join(hookDir, file.Name())
+
+		// execute the binary and capture its error
+		// stream stdout and stderr
+		var stdBuffer bytes.Buffer
+		mw := io.MultiWriter(os.Stdout, &stdBuffer)
+		cmd := exec.Command(binaryPath)
+		cmd.Stdout = mw
+		cmd.Stderr = mw
+		err := cmd.Run()
+		exitCode := cmd.ProcessState.ExitCode()
+
+		var warning string
+		if exitCode == 1 {
+			// for 1 return the error and fail the build
+			return fmt.Errorf("hook %s %d failed with exit code %d: %v", hookName, hookCount, exitCode, err)
+		} else if exitCode > 1 {
+			// if the exit code is greater than 1, we will consider as a warning
+			// set the warning flag for the step footer
+			warning = " WithWarnings"
+			// add to the warnings counter to add to the end of the build to flag build as warning
+			f, err := os.OpenFile("/tmp/warnings", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+			if err != nil {
+				panic(err)
+			}
+			defer f.Close()
+			if _, err = f.WriteString(fmt.Sprintf("%s:%d\n", hookName, hookCount)); err != nil {
+				panic(err)
+			}
+		}
+
+		et := time.Now()
+		diff := time.Time{}.Add(et.Sub(st))
+		tz, _ := et.Zone()
+		// print the step footer for build log parser
+		fmt.Printf("##############################################\nSTEP %s - %d: Completed at %s (%s) Duration %s Elapsed %s%s\n##############################################\n", hookName, hookCount, et.Format("2006-01-02 15:04:05"), tz, diff.Format("15:04:05"), diff.Format("15:04:05"), warning)
+	}
+
+	return nil
+}
+
+func isExecutable(filename string) bool {
+	info, err := os.Stat(filename)
+	if err != nil {
+		return false
+	}
+	return (info.Mode() & 0111) != 0
+}

--- a/legacy/build-deploy.sh
+++ b/legacy/build-deploy.sh
@@ -9,6 +9,8 @@ echo "##############################################"
 
 NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
 LAGOON_VERSION=$(cat /lagoon/version)
+export NAMESPACE
+export LAGOON_VERSION
 
 echo -e "##############################################\nBEGIN Checkout Repository\n##############################################"
 if [ "$BUILD_TYPE" == "pullrequest" ]; then


### PR DESCRIPTION
This adds support for build hooks. This is where an operator of a Lagoon can customise their build image to add hooks that can perform additional functionality during a build.

This is designed mainly as a way to augment a build, rather than perform modifications of resources provisioned during a build. Modifying resources provisioned by the build tool outside of the build tool has the potential to cause unexpected or unknown issues.

Hooks are executed in the directory in order, it is recommended to prefix your hooks with incrementing numbers like `01-hook1`, `02-hook2`, etc...

The hooks expect one of the following return codes from any hook scripts used.
0: :white_check_mark: all good.
1: :x: failure will fail the build
2+: :warning: will flag the step with a warning, but the build will continue

Adding scripts needs to be done when building the dockerfile, for example, creating the directory for the hook, and then adding the executable into that directory.
```
RUN mkdir -p /kubectl-build-deploy/hooks/pre-lagoon-yaml-validation
COPY test.sh /kubectl-build-deploy/hooks/pre-lagoon-yaml-validation/01-test.sh
```