### PR TITLE
fix: dont fail if forbidden access to nonstandard crds

### DIFF
--- a/internal/collector/dbaas_consumers.go
+++ b/internal/collector/dbaas_consumers.go
@@ -6,6 +6,7 @@ import (
 	mariadbv1 "github.com/amazeeio/dbaas-operator/apis/mariadb/v1"
 	mongodbv1 "github.com/amazeeio/dbaas-operator/apis/mongodb/v1"
 	postgresv1 "github.com/amazeeio/dbaas-operator/apis/postgres/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -21,7 +22,7 @@ func (c *Collector) CollectMariaDBConsumers(ctx context.Context, namespace strin
 	})
 	list := &mariadbv1.MariaDBConsumerList{}
 	err := c.Client.List(ctx, list, listOption)
-	if err != nil {
+	if apierrors.IsForbidden(err) {
 		return nil, err
 	}
 	return list, nil
@@ -37,7 +38,7 @@ func (c *Collector) CollectMongoDBConsumers(ctx context.Context, namespace strin
 	})
 	list := &mongodbv1.MongoDBConsumerList{}
 	err := c.Client.List(ctx, list, listOption)
-	if err != nil {
+	if apierrors.IsForbidden(err) {
 		return nil, err
 	}
 	return list, nil
@@ -53,7 +54,7 @@ func (c *Collector) CollectPostgreSQLConsumers(ctx context.Context, namespace st
 	})
 	list := &postgresv1.PostgreSQLConsumerList{}
 	err := c.Client.List(ctx, list, listOption)
-	if err != nil {
+	if apierrors.IsForbidden(err) {
 		return nil, err
 	}
 	return list, nil

--- a/internal/collector/prebackuppods.go
+++ b/internal/collector/prebackuppods.go
@@ -5,6 +5,7 @@ import (
 
 	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
 	k8upv1alpha1 "github.com/vshn/k8up/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,7 +21,7 @@ func (c *Collector) CollectPreBackupPodsV1(ctx context.Context, namespace string
 	})
 	list := &k8upv1.PreBackupPodList{}
 	err := c.Client.List(ctx, list, listOption)
-	if err != nil {
+	if apierrors.IsForbidden(err) {
 		return nil, err
 	}
 	return list, nil
@@ -36,7 +37,7 @@ func (c *Collector) CollectPreBackupPodsV1Alpha1(ctx context.Context, namespace 
 	})
 	list := &k8upv1alpha1.PreBackupPodList{}
 	err := c.Client.List(ctx, list, listOption)
-	if err != nil {
+	if apierrors.IsForbidden(err) {
 		return nil, err
 	}
 	return list, nil

--- a/internal/collector/schedules .go
+++ b/internal/collector/schedules .go
@@ -5,6 +5,7 @@ import (
 
 	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
 	k8upv1alpha1 "github.com/vshn/k8up/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,7 +21,7 @@ func (c *Collector) CollectSchedulesV1(ctx context.Context, namespace string) (*
 	})
 	list := &k8upv1.ScheduleList{}
 	err := c.Client.List(ctx, list, listOption)
-	if err != nil {
+	if apierrors.IsForbidden(err) {
 		return nil, err
 	}
 	return list, nil
@@ -36,7 +37,7 @@ func (c *Collector) CollectSchedulesV1Alpha1(ctx context.Context, namespace stri
 	})
 	list := &k8upv1alpha1.ScheduleList{}
 	err := c.Client.List(ctx, list, listOption)
-	if err != nil {
+	if apierrors.IsForbidden(err) {
 		return nil, err
 	}
 	return list, nil


### PR DESCRIPTION
Lagoon has support for dbaas and k8up, however these are optional components. In some instance, a user may get an obscure forbidden error in builds when these CRDs exist, but maybe don't have the full roles associated to them.

This adds a check that if the access to these resources is forbidden, it ignores the error.