### PR TITLE
feat: support for LAGOON_FEATURE_FLAG_INSIGHTS_CORE_ENABLED

### DIFF
--- a/legacy/scripts/exec-generate-insights-configmap.sh
+++ b/legacy/scripts/exec-generate-insights-configmap.sh
@@ -47,6 +47,11 @@ processImageInspect() {
       annotate configmap ${IMAGE_INSPECT_CONFIGMAP} \
       lagoon.sh/branch=${BRANCH}
   fi
+  if [ "$(featureFlag INSIGHTS_CORE_ENABLED | tr '[:upper:]' '[:lower:]')" = "true" ]; then
+    kubectl -n ${NAMESPACE} \
+      annotate configmap ${IMAGE_INSPECT_CONFIGMAP} \
+      core.insights.lagoon.sh/enabled="true"
+  fi
   kubectl \
       -n ${NAMESPACE} \
       label configmap ${IMAGE_INSPECT_CONFIGMAP} \
@@ -106,6 +111,11 @@ processSbom() {
       kubectl -n ${NAMESPACE} \
         annotate configmap ${SBOM_CONFIGMAP} \
         lagoon.sh/branch=${BRANCH}
+    fi
+    if [ "$(featureFlag INSIGHTS_CORE_ENABLED | tr '[:upper:]' '[:lower:]')" = "true" ]; then
+      kubectl -n ${NAMESPACE} \
+        annotate configmap ${SBOM_CONFIGMAP} \
+        core.insights.lagoon.sh/enabled="true"
     fi
     # Support custom Dependency Track integration.
     local apiEndpoint


### PR DESCRIPTION
Check for `LAGOON_FEATURE_FLAG_INSIGHTS_CORE_ENABLED` and annotates the insights config maps accordingly.