### PR TITLE
fix: always check `global` env vars combined with `build` or `runtime`

### DIFF
--- a/cmd/identify_feature.go
+++ b/cmd/identify_feature.go
@@ -40,7 +40,7 @@ func IdentifyFeatureFlag(g generator.GeneratorInput, name string) (string, error
 	if forceFlagVar != "" {
 		return forceFlagVar, nil
 	}
-	featureFlagVar, _ := lagoon.GetLagoonVariable(fmt.Sprintf("%s%s", "LAGOON_FEATURE_FLAG_", name), []string{"build", "global"}, lagoonBuild.BuildValues.EnvironmentVariables)
+	featureFlagVar, _ := lagoon.GetBuildVariable(fmt.Sprintf("%s%s", "LAGOON_FEATURE_FLAG_", name), lagoonBuild.BuildValues.EnvironmentVariables)
 	if featureFlagVar != nil {
 		return featureFlagVar.Value, nil
 	}

--- a/internal/generator/backups.go
+++ b/internal/generator/backups.go
@@ -36,7 +36,7 @@ func generateBackupValues(
 		switch buildValues.BuildType {
 		case "promote":
 			if buildValues.EnvironmentType == "production" {
-				lagoonBackupDevSchedule, _ := lagoon.GetLagoonVariable("LAGOON_BACKUP_PROD_SCHEDULE", []string{"build", "global"}, mergedVariables)
+				lagoonBackupDevSchedule, _ := lagoon.GetBuildVariable("LAGOON_BACKUP_PROD_SCHEDULE", mergedVariables)
 				devBackupSchedule := ""
 				if lagoonBackupDevSchedule != nil {
 					devBackupSchedule = helpers.GetEnv("LAGOON_FEATURE_BACKUP_PROD_SCHEDULE", lagoonBackupDevSchedule.Value, debug)
@@ -49,7 +49,7 @@ func generateBackupValues(
 			}
 		case "branch":
 			if buildValues.EnvironmentType == "production" {
-				lagoonBackupDevSchedule, _ := lagoon.GetLagoonVariable("LAGOON_BACKUP_PROD_SCHEDULE", []string{"build", "global"}, mergedVariables)
+				lagoonBackupDevSchedule, _ := lagoon.GetBuildVariable("LAGOON_BACKUP_PROD_SCHEDULE", mergedVariables)
 				devBackupSchedule := ""
 				if lagoonBackupDevSchedule != nil {
 					devBackupSchedule = helpers.GetEnv("LAGOON_FEATURE_BACKUP_PROD_SCHEDULE", lagoonBackupDevSchedule.Value, debug)
@@ -61,7 +61,7 @@ func generateBackupValues(
 				}
 			}
 			if buildValues.EnvironmentType == "development" {
-				lagoonBackupDevSchedule, _ := lagoon.GetLagoonVariable("LAGOON_BACKUP_DEV_SCHEDULE", []string{"build", "global"}, mergedVariables)
+				lagoonBackupDevSchedule, _ := lagoon.GetBuildVariable("LAGOON_BACKUP_DEV_SCHEDULE", mergedVariables)
 				devBackupSchedule := ""
 				if lagoonBackupDevSchedule != nil {
 					devBackupSchedule = helpers.GetEnv("LAGOON_FEATURE_BACKUP_DEV_SCHEDULE", lagoonBackupDevSchedule.Value, debug)
@@ -73,7 +73,7 @@ func generateBackupValues(
 				}
 			}
 		case "pullrequest":
-			lagoonBackupPRSchedule, _ := lagoon.GetLagoonVariable("LAGOON_BACKUP_PR_SCHEDULE", []string{"build", "global"}, mergedVariables)
+			lagoonBackupPRSchedule, _ := lagoon.GetBuildVariable("LAGOON_BACKUP_PR_SCHEDULE", mergedVariables)
 			prBackupSchedule := ""
 			if lagoonBackupPRSchedule != nil {
 				prBackupSchedule = helpers.GetEnv("LAGOON_FEATURE_BACKUP_PR_SCHEDULE", lagoonBackupPRSchedule.Value, debug)
@@ -81,7 +81,7 @@ func generateBackupValues(
 				prBackupSchedule = helpers.GetEnv("LAGOON_FEATURE_BACKUP_PR_SCHEDULE", prBackupSchedule, debug)
 			}
 			if prBackupSchedule == "" {
-				lagoonBackupDevSchedule, _ := lagoon.GetLagoonVariable("LAGOON_BACKUP_DEV_SCHEDULE", []string{"build", "global"}, mergedVariables)
+				lagoonBackupDevSchedule, _ := lagoon.GetBuildVariable("LAGOON_BACKUP_DEV_SCHEDULE", mergedVariables)
 				if lagoonBackupDevSchedule != nil {
 					newBackupSchedule = helpers.GetEnv("LAGOON_FEATURE_BACKUP_DEV_SCHEDULE", lagoonBackupDevSchedule.Value, debug)
 				} else {
@@ -158,7 +158,7 @@ func generateBackupValues(
 	}
 
 	// work out the bucket name
-	lagoonBaaSBackupBucket, _ := lagoon.GetLagoonVariable("LAGOON_BAAS_BUCKET_NAME", []string{"build", "global"}, mergedVariables)
+	lagoonBaaSBackupBucket, _ := lagoon.GetBuildVariable("LAGOON_BAAS_BUCKET_NAME", mergedVariables)
 	if lagoonBaaSBackupBucket != nil {
 		buildValues.Backup.S3BucketName = lagoonBaaSBackupBucket.Value
 	} else {
@@ -171,24 +171,24 @@ func generateBackupValues(
 	}
 
 	// check for custom baas backup variables in the API
-	lagoonBaaSCustomBackupEndpoint, _ := lagoon.GetLagoonVariable("LAGOON_BAAS_CUSTOM_BACKUP_ENDPOINT", []string{"build", "global"}, mergedVariables)
+	lagoonBaaSCustomBackupEndpoint, _ := lagoon.GetBuildVariable("LAGOON_BAAS_CUSTOM_BACKUP_ENDPOINT", mergedVariables)
 	if lagoonBaaSCustomBackupEndpoint != nil {
 		buildValues.Backup.S3Endpoint = lagoonBaaSCustomBackupEndpoint.Value
 	}
-	lagoonBaaSCustomBackupBucket, _ := lagoon.GetLagoonVariable("LAGOON_BAAS_CUSTOM_BACKUP_BUCKET", []string{"build", "global"}, mergedVariables)
+	lagoonBaaSCustomBackupBucket, _ := lagoon.GetBuildVariable("LAGOON_BAAS_CUSTOM_BACKUP_BUCKET", mergedVariables)
 	if lagoonBaaSCustomBackupBucket != nil {
 		buildValues.Backup.S3BucketName = lagoonBaaSCustomBackupBucket.Value
 	}
-	lagoonBaaSCustomBackupAccessKey, _ := lagoon.GetLagoonVariable("LAGOON_BAAS_CUSTOM_BACKUP_ACCESS_KEY", []string{"build", "global"}, mergedVariables)
-	lagoonBaaSCustomBackupSecretKey, _ := lagoon.GetLagoonVariable("LAGOON_BAAS_CUSTOM_BACKUP_SECRET_KEY", []string{"build", "global"}, mergedVariables)
+	lagoonBaaSCustomBackupAccessKey, _ := lagoon.GetBuildVariable("LAGOON_BAAS_CUSTOM_BACKUP_ACCESS_KEY", mergedVariables)
+	lagoonBaaSCustomBackupSecretKey, _ := lagoon.GetBuildVariable("LAGOON_BAAS_CUSTOM_BACKUP_SECRET_KEY", mergedVariables)
 	if lagoonBaaSCustomBackupAccessKey != nil && lagoonBaaSCustomBackupSecretKey != nil {
 		buildValues.Backup.CustomLocation.BackupLocationAccessKey = lagoonBaaSCustomBackupAccessKey.Value
 		buildValues.Backup.CustomLocation.BackupLocationSecretKey = lagoonBaaSCustomBackupSecretKey.Value
 		buildValues.Backup.S3SecretName = "lagoon-baas-custom-backup-credentials"
 	}
 	// check for custom baas restore variables
-	lagoonBaaSCustomRestoreAccessKey, _ := lagoon.GetLagoonVariable("LAGOON_BAAS_CUSTOM_RESTORE_ACCESS_KEY", []string{"build", "global"}, mergedVariables)
-	lagoonBaaSCustomRestoreSecretKey, _ := lagoon.GetLagoonVariable("LAGOON_BAAS_CUSTOM_RESTORE_SECRET_KEY", []string{"build", "global"}, mergedVariables)
+	lagoonBaaSCustomRestoreAccessKey, _ := lagoon.GetBuildVariable("LAGOON_BAAS_CUSTOM_RESTORE_ACCESS_KEY", mergedVariables)
+	lagoonBaaSCustomRestoreSecretKey, _ := lagoon.GetBuildVariable("LAGOON_BAAS_CUSTOM_RESTORE_SECRET_KEY", mergedVariables)
 	if lagoonBaaSCustomRestoreAccessKey != nil && lagoonBaaSCustomRestoreSecretKey != nil {
 		buildValues.Backup.CustomLocation.RestoreLocationAccessKey = lagoonBaaSCustomRestoreAccessKey.Value
 		buildValues.Backup.CustomLocation.RestoreLocationSecretKey = lagoonBaaSCustomRestoreSecretKey.Value

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -413,7 +413,7 @@ func NewGenerator(
 
 	// get any variables from the API here that could be used to influence a build or services within the environment
 	// collect docker buildkit value
-	dockerBuildKit, _ := lagoon.GetLagoonVariable("DOCKER_BUILDKIT", []string{"build", "global"}, buildValues.EnvironmentVariables)
+	dockerBuildKit, _ := lagoon.GetBuildVariable("DOCKER_BUILDKIT", buildValues.EnvironmentVariables)
 	if dockerBuildKit != nil {
 		bk, _ := strconv.ParseBool(dockerBuildKit.Value)
 		buildValues.DockerBuildKit = &bk

--- a/internal/generator/ingress.go
+++ b/internal/generator/ingress.go
@@ -318,7 +318,7 @@ func getRoutesFromAPIEnvVar(
 	debug bool,
 ) (*lagoon.RoutesV2, error) {
 	apiRoutes := &lagoon.RoutesV2{}
-	lagoonRoutesJSON, _ := lagoon.GetLagoonVariable("LAGOON_ROUTES_JSON", []string{"build", "global"}, envVars)
+	lagoonRoutesJSON, _ := lagoon.GetBuildVariable("LAGOON_ROUTES_JSON", envVars)
 	lagoonAPIRoutes, _ := lagoon.GetLagoonVariable("LAGOON_API_ROUTES", []string{"internal_system"}, envVars)
 	// if `LAGOON_ROUTES_JSON` is present, prefer it first to so not to break existing configurations
 	if lagoonRoutesJSON != nil {

--- a/internal/lagoon/fastly.go
+++ b/internal/lagoon/fastly.go
@@ -25,7 +25,7 @@ func GenerateFastlyConfiguration(f *Fastly, noCacheServiceID, serviceID, route s
 	// this is supported as `SERVICE_ID:WATCH_STATUS:SECRET_NAME(optional)` eg: "fa23rsdgsdgas:false", "fa23rsdgsdgas:true" or "fa23rsdgsdgas:true:examplecom"
 	// this will apply to ALL ingresses if one is not specifically defined in the `LAGOON_FASTLY_SERVICE_IDS` environment variable override
 	// see section `FASTLY SERVICE ID PER INGRESS OVERRIDE` in `build-deploy-docker-compose.sh` for info on `LAGOON_FASTLY_SERVICE_IDS`
-	lfsID, err := GetLagoonVariable("LAGOON_FASTLY_SERVICE_ID", []string{"build", "global"}, variables)
+	lfsID, err := GetBuildVariable("LAGOON_FASTLY_SERVICE_ID", variables)
 	if err == nil {
 		lfsIDSplit := strings.Split(lfsID.Value, ":")
 		// default watch status to true
@@ -54,7 +54,7 @@ func GenerateFastlyConfiguration(f *Fastly, noCacheServiceID, serviceID, route s
 	// # Example 3: www.example.com:x1s8asfafasf7ssf:true:examplecom
 	// # ^^^ tells the ingress creation to use the service id x1s8asfafasf7ssf for ingress www.example.com, with the watch status of true
 	// # but it will also be annotated to be told to use the secret named `examplecom` that could be defined elsewhere
-	lfsIDs, err := GetLagoonVariable("LAGOON_FASTLY_SERVICE_IDS", []string{"build", "global"}, variables)
+	lfsIDs, err := GetBuildVariable("LAGOON_FASTLY_SERVICE_IDS", variables)
 	if err == nil {
 		lfsIDsSplit := strings.Split(lfsIDs.Value, ",")
 		for _, lfs := range lfsIDsSplit {

--- a/internal/lagoon/variables.go
+++ b/internal/lagoon/variables.go
@@ -72,6 +72,12 @@ func GetLagoonVariable(name string, scope []string, variables []EnvironmentVaria
 	return nil, fmt.Errorf("variable %s not found", name)
 }
 
+// GetBuildVariable returns a `build` scoped environment variable
+func GetBuildVariable(name string, variables []EnvironmentVariable) (*EnvironmentVariable, error) {
+	buildVar, err := GetLagoonVariable(name, []string{"build", "global"}, variables)
+	return buildVar, err
+}
+
 // VariableExists checks if a variable exists in a slice of environment variables
 func VariableExists(vars *[]EnvironmentVariable, name, value string) bool {
 	exists := false

--- a/internal/lagoon/variables_test.go
+++ b/internal/lagoon/variables_test.go
@@ -252,6 +252,73 @@ func TestGetLagoonVariable(t *testing.T) {
 	}
 }
 
+func TestGetBuildVariable(t *testing.T) {
+	envVars := []EnvironmentVariable{
+		{
+			Name:  "LAGOON_FEATURE_FLAG_INSIGHTS",
+			Value: "enabled",
+			Scope: "global",
+		},
+		{
+			Name:  "LAGOON_FASTLY_SERVICE_ID",
+			Value: "1234567",
+			Scope: "build",
+		},
+		{
+			Name:  "PHP_MEMORY_LIMIT",
+			Value: "5G",
+			Scope: "runtime",
+		},
+	}
+
+	tests := []struct {
+		name    string
+		varName string
+		want    *EnvironmentVariable
+		wantErr bool
+	}{
+		{
+			name:    "test1",
+			varName: "LAGOON_FASTLY_SERVICE_ID",
+			want: &EnvironmentVariable{
+				Name:  "LAGOON_FASTLY_SERVICE_ID",
+				Value: "1234567",
+				Scope: "build",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "test2",
+			varName: "LAGOON_FEATURE_FLAG_INSIGHTS",
+			want: &EnvironmentVariable{
+				Name:  "LAGOON_FEATURE_FLAG_INSIGHTS",
+				Value: "enabled",
+				Scope: "global",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "test3",
+			varName: "PHP_MEMORY_LIMIT",
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetBuildVariable(tt.varName, envVars)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetBuildVariable() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetBuildVariable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+}
+
 func TestVariableExists(t *testing.T) {
 	type args struct {
 		vars  *[]EnvironmentVariable

--- a/legacy/build-deploy-docker-compose.sh
+++ b/legacy/build-deploy-docker-compose.sh
@@ -437,14 +437,14 @@ if [ "${LAGOON_VARIABLES_ONLY}" != "true" ]; then
       # this logic will make development environments return an error by default
       # adding LAGOON_FEATURE_FLAG_DEVELOPMENT_DOCKER_COMPOSE_VALIDATION=disabled can be used to disable the error and revert to a warning per project or environment
       # or add LAGOON_FEATURE_FLAG_DEFAULT_DEVELOPMENT_DOCKER_COMPOSE_VALIDATION=disabled to the remote-controller as a default to disable for a cluster
-      if [[ "$(featureFlag DEVELOPMENT_DOCKER_COMPOSE_VALIDATION)" != disabled ]] && [[ "$ENVIRONMENT_TYPE" == "development" ]]; then
+      if [[ "$(featureFlag DEVELOPMENT_DOCKER_COMPOSE_VALIDATION | tr '[:upper:]' '[:lower:]')" != disabled ]] && [[ "$ENVIRONMENT_TYPE" == "development" ]]; then
         DOCKER_COMPOSE_VALIDATION_ERROR=true
       fi
       # by default, production environments won't return an error unless the feature flag is enabled.
       # this allows using the feature flag to selectively apply to production environments if required
       # adding LAGOON_FEATURE_FLAG_PRODUCTION_DOCKER_COMPOSE_VALIDATION=enabled can be used to enable the error per project or environment
       # or add LAGOON_FEATURE_FLAG_DEFAULT_PRODUCTION_DOCKER_COMPOSE_VALIDATION=enabled to the remote-controller as a default to disable for a cluster
-      if [[ "$(featureFlag PRODUCTION_DOCKER_COMPOSE_VALIDATION)" = enabled ]] && [[ "$ENVIRONMENT_TYPE" == "production" ]]; then
+      if [[ "$(featureFlag PRODUCTION_DOCKER_COMPOSE_VALIDATION | tr '[:upper:]' '[:lower:]')" = enabled ]] && [[ "$ENVIRONMENT_TYPE" == "production" ]]; then
         DOCKER_COMPOSE_VALIDATION_ERROR=true
       DOCKER_COMPOSE_VALIDATION_ERROR_VARIABLE=LAGOON_FEATURE_FLAG_PRODUCTION_DOCKER_COMPOSE_VALIDATION
       fi
@@ -1218,7 +1218,7 @@ if [ "${LAGOON_VARIABLES_ONLY}" != "true" ]; then
       # usually this is because of a bad merge or something, and people generally aren't reading warnings anyway
       echo ">> Lagoon detected routes that have been removed from the .lagoon.yml or Lagoon API"
       echo "> If you need these routes, you should update your .lagoon.yml file and make sure the routes exist."
-      if [ "$(featureFlag CLEANUP_REMOVED_LAGOON_ROUTES)" != enabled ]; then
+      if [ "$(featureFlag CLEANUP_REMOVED_LAGOON_ROUTES | tr '[:upper:]' '[:lower:]')" != enabled ]; then
         echo "> If you no longer need these routes, you can instruct Lagoon to remove it from the environment by setting the following variable"
         echo "> 'LAGOON_FEATURE_FLAG_CLEANUP_REMOVED_LAGOON_ROUTES=enabled' as a BUILD scoped variable to this environment or project"
         echo "> You should remove this variable after the deployment has been completed, otherwise future route removals will happen automatically"
@@ -1229,7 +1229,7 @@ if [ "${LAGOON_VARIABLES_ONLY}" != "true" ]; then
       echo "> Future releases of Lagoon may remove routes automatically, you should ensure that your routes are up always up to date if you see this warning"
       for DI in ${DELETE_INGRESS[@]}
       do
-        if [ "$(featureFlag CLEANUP_REMOVED_LAGOON_ROUTES)" = enabled ]; then
+        if [ "$(featureFlag CLEANUP_REMOVED_LAGOON_ROUTES | tr '[:upper:]' '[:lower:]')" = enabled ]; then
           if kubectl -n ${NAMESPACE} get ingress ${DI} &> /dev/null; then
             echo ">> Removing ingress ${DI}"
             cleanupCertificates "${DI}" "false"
@@ -1594,7 +1594,7 @@ if [ "${LAGOON_VARIABLES_ONLY}" != "true" ]; then
     # check if k8up v2 feature flag is enabled
     LAGOON_BACKUP_YAML_FOLDER="/kubectl-build-deploy/lagoon/backup"
     mkdir -p $LAGOON_BACKUP_YAML_FOLDER
-    if [ "$(featureFlag K8UP_V2)" = enabled ]; then
+    if [ "$(featureFlag K8UP_V2 | tr '[:upper:]' '[:lower:]')" = enabled ]; then
     # build-tool doesn't do any capability checks yet, so do this for now
       if kubectl -n ${NAMESPACE} get schedule.k8up.io &> /dev/null; then
       echo "Backups: generating k8up.io/v1 resources"
@@ -1894,7 +1894,7 @@ if [ "${LAGOON_VARIABLES_ONLY}" != "true" ]; then
   finalizeBuildStep "${buildStartTime}" "${previousStepEnd}" "${currentStepEnd}" "${NAMESPACE}" "deployCompleted" "Build and Deploy" "false"
   previousStepEnd=${currentStepEnd}
 
-  if [ "$(featureFlag INSIGHTS)" = enabled ]; then
+  if [ "$(featureFlag INSIGHTS | tr '[:upper:]' '[:lower:]')" = enabled ]; then
     beginBuildStep "Insights Gathering" "gatheringInsights"
     ##############################################
     ### RUN insights gathering and store in configmap


### PR DESCRIPTION
This fixes two annoyances around the use of Lagoon env var feature flags.

The first issues is a few places in the code that looks up environment variables treats the `global` scope like a third type. There is never a case where the `global` scope should be checked alone, it should always be combined with `build` or `runtime`. And vice-versa, checking for `runtime` or `build` scoped env vars should also always check in `global`.

The second is some feature flag value comparisons happen in bash which was done in a case sensitive way.