### PR TITLE
feat: support for disabling key mount in cli and worker types

### DIFF
--- a/cmd/template_lagoonservices_test.go
+++ b/cmd/template_lagoonservices_test.go
@@ -653,6 +653,22 @@ func TestTemplateLagoonServices(t *testing.T) {
 				}, true),
 			want: "internal/testdata/basic/service-templates/test-basic-deployment-revision-history",
 		},
+		{
+			name:        "test-basic-deployment-cli-keymount",
+			description: "tests a basic deployment with a cli pod with the key not mounted",
+			args: testdata.GetSeedData(
+				testdata.TestData{
+					ProjectName:     "example-project",
+					EnvironmentName: "main",
+					Branch:          "main",
+					LagoonYAML:      "internal/testdata/basic/lagoon.cli-key.yml",
+					ImageReferences: map[string]string{
+						"cli":   "harbor.example/example-project/main/cli@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8",
+						"basic": "harbor.example/example-project/main/basic@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8",
+					},
+				}, true),
+			want: "internal/testdata/basic/service-templates/test-basic-deployment-cli-keymount",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/generator/buildvalues.go
+++ b/internal/generator/buildvalues.go
@@ -212,6 +212,7 @@ type ServiceValues struct {
 	AdditionalVolumes                      []ServiceVolume         `json:"additionalVolumes,omitempty"`
 	CreateDefaultVolume                    bool                    `json:"createDefaultVolume"`
 	ExternalServiceName                    string                  `json:"externalServiceName,omitempty"`
+	MountSSHKey                            *bool                   `json:"mountSSHKey"`
 }
 
 type ExternalService struct {

--- a/internal/generator/services.go
+++ b/internal/generator/services.go
@@ -567,6 +567,30 @@ func composeToServiceValues(
 				cService.AdditionalServicePorts = append(cService.AdditionalServicePorts, newService)
 			}
 		}
+		// handle development environment override
+		mountSSHKey := lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, "lagoon.service.development.mountsshkey")
+		if mountSSHKey != "" && buildValues.EnvironmentType == "development" {
+			if !servicetypes.SupportMountSSHKey(lagoonType) {
+				return nil, fmt.Errorf(
+					"lagoon.type '%s' does not support mounting ssh key",
+					lagoonType,
+				)
+			}
+			b, _ := strconv.ParseBool(mountSSHKey)
+			cService.MountSSHKey = &b
+		}
+		// handle production environment override
+		mountSSHKey = lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, "lagoon.service.production.mountsshkey")
+		if mountSSHKey != "" && buildValues.EnvironmentType == "production" {
+			if !servicetypes.SupportMountSSHKey(lagoonType) {
+				return nil, fmt.Errorf(
+					"lagoon.type '%s' does not support mounting ssh key",
+					lagoonType,
+				)
+			}
+			b, _ := strconv.ParseBool(mountSSHKey)
+			cService.MountSSHKey = &b
+		}
 		return cService, nil
 	}
 }

--- a/internal/servicetypes/cli.go
+++ b/internal/servicetypes/cli.go
@@ -1,7 +1,6 @@
 package servicetypes
 
 import (
-	"github.com/uselagoon/build-deploy-tool/internal/helpers"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -10,29 +9,12 @@ import (
 var cli = ServiceType{
 	Name:                   "cli",
 	AllowAdditionalVolumes: true,
+	AllowSSHKeyMount:       true,
 	PrimaryContainer: ServiceContainer{
 		Name: "cli",
-		Volumes: []corev1.Volume{
-			{
-				Name: "lagoon-sshkey",
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						DefaultMode: helpers.Int32Ptr(420),
-						SecretName:  "lagoon-sshkey",
-					},
-				},
-			},
-		},
 		Container: corev1.Container{
 			ImagePullPolicy: corev1.PullAlways,
 			SecurityContext: &corev1.SecurityContext{},
-			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      "lagoon-sshkey",
-					ReadOnly:  true,
-					MountPath: "/var/run/secrets/lagoon/sshkey/",
-				},
-			},
 			ReadinessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					Exec: &corev1.ExecAction{
@@ -62,6 +44,7 @@ var cliPersistent = ServiceType{
 	Name:                     "cli-persistent",
 	ConsumesPersistentVolume: true,
 	AllowAdditionalVolumes:   true,
+	AllowSSHKeyMount:         true,
 	PrimaryContainer: ServiceContainer{
 		Name:      cli.PrimaryContainer.Name,
 		Container: cli.PrimaryContainer.Container,

--- a/internal/servicetypes/types.go
+++ b/internal/servicetypes/types.go
@@ -19,6 +19,7 @@ type ServiceType struct {
 	ProvidesPersistentVolume bool
 	ConsumesPersistentVolume bool
 	AllowAdditionalVolumes   bool
+	AllowSSHKeyMount         bool
 }
 
 type ServicePodSecurityContext struct {
@@ -192,4 +193,8 @@ func ConvertOldServiceType(lagoonType string) string {
 		return val
 	}
 	return lagoonType
+}
+
+func SupportMountSSHKey(lagoonType string) bool {
+	return ServiceTypes[lagoonType].AllowSSHKeyMount
 }

--- a/internal/servicetypes/worker.go
+++ b/internal/servicetypes/worker.go
@@ -1,7 +1,6 @@
 package servicetypes
 
 import (
-	"github.com/uselagoon/build-deploy-tool/internal/helpers"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -9,19 +8,9 @@ import (
 var worker = ServiceType{
 	Name:                   "worker",
 	AllowAdditionalVolumes: true,
+	AllowSSHKeyMount:       true,
 	PrimaryContainer: ServiceContainer{
 		Name: "worker",
-		Volumes: []corev1.Volume{
-			{
-				Name: "lagoon-sshkey",
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						DefaultMode: helpers.Int32Ptr(420),
-						SecretName:  "lagoon-sshkey",
-					},
-				},
-			},
-		},
 		Container: corev1.Container{
 			ImagePullPolicy: corev1.PullAlways,
 			SecurityContext: &corev1.SecurityContext{},
@@ -39,13 +28,6 @@ var worker = ServiceType{
 				PeriodSeconds:       2,
 				FailureThreshold:    3,
 			},
-			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      "lagoon-sshkey",
-					ReadOnly:  true,
-					MountPath: "/var/run/secrets/lagoon/sshkey/",
-				},
-			},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("10m"),
@@ -60,9 +42,9 @@ var workerPersistent = ServiceType{
 	Name:                     "worker-persistent",
 	ConsumesPersistentVolume: true,
 	AllowAdditionalVolumes:   true,
+	AllowSSHKeyMount:         true,
 	PrimaryContainer: ServiceContainer{
 		Name:      worker.PrimaryContainer.Name,
 		Container: worker.PrimaryContainer.Container,
-		Volumes:   worker.PrimaryContainer.Volumes,
 	},
 }

--- a/internal/templating/template_podspec.go
+++ b/internal/templating/template_podspec.go
@@ -163,7 +163,18 @@ func generatePodTemplateSpec(
 			}
 		}
 	}
-	// start set up any volumes this cronjob can use
+	// start set up any volumes this pod can use
+	if serviceTypeValues.AllowSSHKeyMount && serviceValues.MountSSHKey == nil || serviceValues.MountSSHKey != nil && *serviceValues.MountSSHKey {
+		podTemplateSpec.Spec.Volumes = append(podTemplateSpec.Spec.Volumes, corev1.Volume{
+			Name: "lagoon-sshkey",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					DefaultMode: helpers.Int32Ptr(420),
+					SecretName:  "lagoon-sshkey",
+				},
+			},
+		})
+	}
 	// first handle any dynamic secret volumes that come from kubernetes secrets that are labeled
 	for _, dsv := range buildValues.DynamicSecretVolumes {
 		volume := corev1.Volume{
@@ -328,6 +339,13 @@ func generatePodTemplateSpec(
 	}
 
 	// mount the volumes in the primary container
+	if serviceTypeValues.AllowSSHKeyMount && serviceValues.MountSSHKey == nil || serviceValues.MountSSHKey != nil && *serviceValues.MountSSHKey {
+		container.Container.VolumeMounts = append(container.Container.VolumeMounts, corev1.VolumeMount{
+			Name:      "lagoon-sshkey",
+			ReadOnly:  true,
+			MountPath: "/var/run/secrets/lagoon/sshkey/",
+		})
+	}
 	for _, dsm := range buildValues.DynamicSecretMounts {
 		volumeMount := corev1.VolumeMount{
 			Name:      dsm.Name,

--- a/internal/testdata/basic/docker-compose.cli-key.yml
+++ b/internal/testdata/basic/docker-compose.cli-key.yml
@@ -1,0 +1,34 @@
+version: '2'
+services:
+  cli:
+    build:
+      context: internal/testdata/basic/docker
+      dockerfile: basic.dockerfile
+    image: builder
+    labels:
+      lagoon.type: cli-persistent
+      lagoon.persistent: /var/lib/basic
+      lagoon.persistent.name: basic
+      lagoon.service.development.mountsshkey: false
+      lagoon.service.production.mountsshkey: false
+  basic:
+    networks:
+      - amazeeio-network
+      - default
+    build:
+      context: internal/testdata/basic/docker
+      dockerfile: basic.dockerfile
+    labels:
+      lagoon.type: basic-persistent
+      lagoon.persistent: /var/lib/basic
+      lagoon.persistent.name: basic
+    volumes:
+      - .:/app:delegated
+    ports:
+      - '1234'
+      - '8191'
+      - '9001/udp'
+
+networks:
+  amazeeio-network:
+    external: true

--- a/internal/testdata/basic/lagoon.cli-key.yml
+++ b/internal/testdata/basic/lagoon.cli-key.yml
@@ -1,0 +1,10 @@
+docker-compose-yaml: internal/testdata/basic/docker-compose.cli-key.yml
+
+environment_variables:
+  git_sha: "true"
+
+environments:
+  main:
+    routes:
+      - node:
+          - example.com

--- a/internal/testdata/basic/service-templates/test-basic-deployment-cli-keymount/deployment-basic.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-deployment-cli-keymount/deployment-basic.yaml
@@ -1,0 +1,91 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  labels:
+    app.kubernetes.io/instance: basic
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: basic-persistent
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic
+    lagoon.sh/service-type: basic-persistent
+    lagoon.sh/template: basic-persistent-0.1.0
+  name: basic
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: basic
+      app.kubernetes.io/name: basic-persistent
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        lagoon.sh/branch: main
+        lagoon.sh/configMapSha: abcdefg1234567890
+        lagoon.sh/version: v2.7.x
+      labels:
+        app.kubernetes.io/instance: basic
+        app.kubernetes.io/managed-by: build-deploy-tool
+        app.kubernetes.io/name: basic-persistent
+        lagoon.sh/buildType: branch
+        lagoon.sh/environment: main
+        lagoon.sh/environmentType: production
+        lagoon.sh/project: example-project
+        lagoon.sh/service: basic
+        lagoon.sh/service-type: basic-persistent
+        lagoon.sh/template: basic-persistent-0.1.0
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - env:
+        - name: LAGOON_GIT_SHA
+          value: abcdefg123456
+        - name: CRONJOBS
+        - name: SERVICE_NAME
+          value: basic
+        envFrom:
+        - secretRef:
+            name: lagoon-platform-env
+        - secretRef:
+            name: lagoon-env
+        image: harbor.example/example-project/main/basic@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8
+        imagePullPolicy: Always
+        livenessProbe:
+          initialDelaySeconds: 60
+          tcpSocket:
+            port: 3000
+          timeoutSeconds: 10
+        name: basic
+        ports:
+        - containerPort: 3000
+          name: http
+          protocol: TCP
+        readinessProbe:
+          initialDelaySeconds: 1
+          tcpSocket:
+            port: 3000
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext: {}
+        volumeMounts:
+        - mountPath: /var/lib/basic
+          name: basic
+      enableServiceLinks: false
+      imagePullSecrets:
+      - name: lagoon-internal-registry-secret
+      priorityClassName: lagoon-priority-production
+      volumes:
+      - name: basic
+        persistentVolumeClaim:
+          claimName: basic
+status: {}

--- a/internal/testdata/basic/service-templates/test-basic-deployment-cli-keymount/deployment-cli.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-deployment-cli-keymount/deployment-cli.yaml
@@ -74,30 +74,18 @@ spec:
             memory: 10Mi
         securityContext: {}
         volumeMounts:
-        - mountPath: /var/run/secrets/lagoon/sshkey/
-          name: lagoon-sshkey
-          readOnly: true
-        - mountPath: /app/otherfiles/
-          name: custom-files
-        - mountPath: /app/web/sites/default/files//php
-          name: nginx-twig
-        - mountPath: /app/web/sites/default/files/
-          name: nginx
+        - mountPath: /var/lib/basic/php
+          name: basic-twig
+        - mountPath: /var/lib/basic
+          name: basic
       enableServiceLinks: false
       imagePullSecrets:
       - name: lagoon-internal-registry-secret
       priorityClassName: lagoon-priority-production
       volumes:
-      - name: lagoon-sshkey
-        secret:
-          defaultMode: 420
-          secretName: lagoon-sshkey
-      - name: custom-files
-        persistentVolumeClaim:
-          claimName: custom-files
       - emptyDir: {}
-        name: nginx-twig
-      - name: nginx
+        name: basic-twig
+      - name: basic
         persistentVolumeClaim:
-          claimName: nginx
+          claimName: basic
 status: {}

--- a/internal/testdata/basic/service-templates/test-basic-deployment-cli-keymount/pvc-basic.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-deployment-cli-keymount/pvc-basic.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    k8up.io/backup: "true"
+    k8up.syn.tools/backup: "true"
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  labels:
+    app.kubernetes.io/instance: basic
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: basic-persistent
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic
+    lagoon.sh/service-type: basic-persistent
+    lagoon.sh/template: basic-persistent-0.1.0
+  name: basic
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: bulk
+status: {}

--- a/internal/testdata/basic/service-templates/test-basic-deployment-cli-keymount/service-basic.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-deployment-cli-keymount/service-basic.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  labels:
+    app.kubernetes.io/instance: basic
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: basic-persistent
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic
+    lagoon.sh/service-type: basic-persistent
+    lagoon.sh/template: basic-persistent-0.1.0
+  name: basic
+spec:
+  ports:
+  - name: http
+    port: 3000
+    protocol: TCP
+    targetPort: http
+  selector:
+    app.kubernetes.io/instance: basic
+    app.kubernetes.io/name: basic-persistent
+status:
+  loadBalancer: {}


### PR DESCRIPTION
This implements optional lagoon project ssh key mounting in `cli` and `worker` pods. This only applies to these two service types and their `-persistent` counterparts.

The default for these services is to mount the key, however there are two labels you can add to the service you want to not mount keys in.
`lagoon.service.development.mountsshkey` - This can be set to `false` to not mount the key in `development` environments only.
`lagoon.service.production.mountsshkey` - This can be set to `false` to not mount the key in `production` environments only.