### PR TITLE
Update Renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,10 @@
   "baseBranches": [
     "main"
   ],
+  "ignorePaths": [
+    "internal/testdata/**",
+    "**/testdata/**"
+  ],
   "extends": [
     "mergeConfidence:all-badges",
     "config:recommended",
@@ -34,6 +38,15 @@
   "packageRules": [
     {
       "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "github.com/compose-spec/compose-go"
+      ],
+      "enabled": false
+    },
+    {
+      "matchManagers": [
         "github-actions"
       ],
       "groupName": "GitHub actions monthly minor/patch",
@@ -45,6 +58,7 @@
       "schedule": [
         "on the first day of the month"
       ],
+      "minimumReleaseAge": "7 days",
       "automerge": true,
       "automergeType": "pr"
     },
@@ -56,6 +70,7 @@
       "matchUpdateTypes": [
         "major"
       ],
+      "minimumReleaseAge": "7 days",
       "automerge": true,
       "automergeType": "pr"
     },
@@ -76,6 +91,27 @@
     {
       "matchPackageNames": ["kubernetes/kubernetes", "helm/helm", "mikefarah/yq"],
       "matchUpdateTypes": ["minor", "major"],
+      "draftPR": true
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "groupName": "Go dependencies minor/patch",
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "draftPR": true
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "groupName": "Go dependencies major",
+      "matchUpdateTypes": [
+        "major"
+      ],
       "draftPR": true
     }
   ]


### PR DESCRIPTION
This pull request updates the Renovate configuration to improve dependency update workflows and provide better control over automated PRs. The main changes include excluding test data directories from Renovate, disabling updates for a specific Go module, grouping Go dependency updates, and enforcing a minimum release age before automerging major updates.

**Dependency update configuration improvements:**

* Excluded all `testdata` directories (including `internal/testdata/**` and `**/testdata/**`) from Renovate updates to avoid unnecessary PRs for test fixtures.
* Disabled Renovate updates for the `github.com/compose-spec/compose-go` module to prevent unwanted changes for this dependency.

**Dependency grouping and automerge controls:**

* Added grouping for Go module (`gomod`) updates: minor/patch updates are grouped into "Go dependencies minor/patch" draft PRs, and major updates are grouped into "Go dependencies major" draft PRs, improving PR organization and review process.
* Enforced a minimum release age of 7 days before automergin github action updates, reducing risk from newly released versions.