### PR TITLE
Updates redis backup to only copy non-temp root rdb files

### DIFF
--- a/internal/servicetypes/redis.go
+++ b/internal/servicetypes/redis.go
@@ -91,7 +91,7 @@ var redisPersistent = ServiceType{
 		PersistentVolumeType: corev1.ReadWriteOnce,
 		PersistentVolumePath: "/data",
 		BackupConfiguration: BackupConfiguration{
-			Command:       `/bin/sh -c "timeout 5400 tar -cf - -C {{ if .ServiceValues.PersistentVolumePath }}{{.ServiceValues.PersistentVolumePath}}{{else}}{{.ServiceTypeValues.Volumes.PersistentVolumePath}}{{end}} ."`,
+			Command:       `/bin/sh -c "timeout 5400 tar -cf - -C {{ if .ServiceValues.PersistentVolumePath }}{{.ServiceValues.PersistentVolumePath}}{{else}}{{.ServiceTypeValues.Volumes.PersistentVolumePath}}{{end}} --exclude='temp-*.rdb' *.rdb"`,
 			FileExtension: ".{{ .ServiceValues.OverrideName }}.tar",
 		},
 	},

--- a/internal/templating/test-resources/deployment/result-redis-1.yaml
+++ b/internal/templating/test-resources/deployment/result-redis-1.yaml
@@ -118,7 +118,7 @@ spec:
     metadata:
       annotations:
         k8up.syn.tools/backupcommand: /bin/sh -c "timeout 5400 tar -cf - -C /data
-          ."
+          --exclude='temp-*.rdb' *.rdb"
         k8up.syn.tools/file-extension: .redis-persist.tar
         lagoon.sh/branch: environment-name
         lagoon.sh/configMapSha: 32bf1359ac92178c8909f0ef938257b477708aa0d78a5a15ad7c2d7919adf273

--- a/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-redis-persist.yaml
+++ b/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-redis-persist.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         k8up.syn.tools/backupcommand: /bin/sh -c "timeout 5400 tar -cf - -C /data
-          ."
+          --exclude='temp-*.rdb' *.rdb"
         k8up.syn.tools/file-extension: .redis-persist.tar
         lagoon.sh/branch: main
         lagoon.sh/configMapSha: abcdefg1234567890

--- a/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-redis-session.yaml
+++ b/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-redis-session.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         k8up.syn.tools/backupcommand: /bin/sh -c "timeout 5400 tar -cf - -C /data
-          ."
+          --exclude='temp-*.rdb' *.rdb"
         k8up.syn.tools/file-extension: .redis-session.tar
         lagoon.sh/branch: main
         lagoon.sh/configMapSha: abcdefg1234567890

--- a/internal/testdata/complex/service-templates/test-redis-persistent-k8upv2/deployment-redis.yaml
+++ b/internal/testdata/complex/service-templates/test-redis-persistent-k8upv2/deployment-redis.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        k8up.io/backupcommand: /bin/sh -c "timeout 5400 tar -cf - -C /data ."
+        k8up.io/backupcommand: /bin/sh -c "timeout 5400 tar -cf - -C /data --exclude='temp-*.rdb' *.rdb"
         k8up.io/file-extension: .redis.tar
         lagoon.sh/branch: main
         lagoon.sh/configMapSha: abcdefg1234567890

--- a/internal/testdata/complex/service-templates/test-redis-persistent-k8upv2/deployment-redis.yaml
+++ b/internal/testdata/complex/service-templates/test-redis-persistent-k8upv2/deployment-redis.yaml
@@ -28,7 +28,8 @@ spec:
   template:
     metadata:
       annotations:
-        k8up.io/backupcommand: /bin/sh -c "timeout 5400 tar -cf - -C /data --exclude='temp-*.rdb' *.rdb"
+        k8up.io/backupcommand: /bin/sh -c "timeout 5400 tar -cf - -C /data --exclude='temp-*.rdb'
+          *.rdb"
         k8up.io/file-extension: .redis.tar
         lagoon.sh/branch: main
         lagoon.sh/configMapSha: abcdefg1234567890


### PR DESCRIPTION
This PR updates the backup command only backup root rdp files, rather than the entire directory - this should prevent backup failures when the AOF files are being written to.