### PR TITLE
fix(deps): update shellescape import and tweak go settings

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,7 +41,8 @@
         "gomod"
       ],
       "matchPackageNames": [
-        "github.com/compose-spec/compose-go"
+        "github.com/compose-spec/compose-go",
+        "github.com/imdario/mergo"
       ],
       "enabled": false
     },
@@ -102,16 +103,17 @@
         "minor",
         "patch"
       ],
+      "postUpdateOptions": ["gomodTidy","gomodUpdateImportPaths"],
       "draftPR": true
     },
     {
       "matchManagers": [
         "gomod"
       ],
-      "groupName": "Go dependencies major",
       "matchUpdateTypes": [
         "major"
       ],
+      "postUpdateOptions": ["gomodTidy","gomodUpdateImportPaths"],
       "draftPR": true
     }
   ]

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 testoutput
 coverage.out
+vendor

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/uselagoon/build-deploy-tool
 go 1.25.0
 
 require (
+	al.essio.dev/pkg/shellescape v1.6.0
 	dario.cat/mergo v1.0.2
 	github.com/PaesslerAG/gval v1.2.4
-	github.com/alessio/shellescape v1.4.1
 	github.com/amazeeio/dbaas-operator v0.4.0
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
 	github.com/compose-spec/compose-go v1.2.7

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+al.essio.dev/pkg/shellescape v1.6.0 h1:NxFcEqzFSEVCGN2yq7Huv/9hyCEGVa/TncnOOBBeXHA=
+al.essio.dev/pkg/shellescape v1.6.0/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -75,7 +77,6 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/amazeeio/dbaas-operator v0.4.0 h1:xxbpffB1Y8DlUV+LIIkSH/uwrZqdTVDyFD7hWcOxnog=
 github.com/amazeeio/dbaas-operator v0.4.0/go.mod h1:fbZuWO1a4JhEJZLrSdOg/+YEzGL6yZcGpfHiIqn72dc=
@@ -414,6 +415,7 @@ github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J0b1vyeLSOYI8bm5wbJM/8yDe8=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/internal/generator/services.go
+++ b/internal/generator/services.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/alessio/shellescape"
+	"al.essio.dev/pkg/shellescape"
 	composetypes "github.com/compose-spec/compose-go/types"
 	"github.com/uselagoon/build-deploy-tool/internal/helpers"
 	"github.com/uselagoon/build-deploy-tool/internal/lagoon"


### PR DESCRIPTION
This pull request updates the Go dependency management configuration and refactors the usage of the `shellescape` package. The most important changes are grouped below:

**Dependency management improvements:**

* [`.github/renovate.json`](diffhunk://#diff-f82f7d36a61d22f640c25bdb8b0435bf9cb38679d99d5f460753fa668ee7cdb3L44-R45): Added `github.com/imdario/mergo` to the list of packages managed by Renovate and included `postUpdateOptions` (`gomodTidy`, `gomodUpdateImportPaths`) for both minor/patch and major Go dependency updates, ensuring cleaner and more consistent dependency updates.

**Dependency refactoring:**

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R6-L8): Replaced the `github.com/alessio/shellescape` dependency (v1.4.1) with `al.essio.dev/pkg/shellescape` (v1.6.0), updating to the new module path and a newer version.
* [`internal/generator/services.go`](diffhunk://#diff-65faa4119ec92040bd5c7fd2340103c542310e8e6c846c2ff676333917a2fa51L12-R12): Updated the import statement to use the new `al.essio.dev/pkg/shellescape` path, reflecting the dependency change in the codebase.