### PR TITLE
feat: support for organization deploy key

### DIFF
--- a/legacy/docker-entrypoint.sh
+++ b/legacy/docker-entrypoint.sh
@@ -26,6 +26,11 @@ cp /var/run/secrets/lagoon/ssh/ssh-privatekey ~/.ssh/key
 # Add a new line to the key, as some ssh key formats need a new line
 echo "" >> ~/.ssh/key
 
+if [ -f /var/run/secrets/lagoon/organization/ssh-privatekey ]; then
+    cp -f /var/run/secrets/lagoon/organization/ssh-privatekey ~/.ssh/organization
+    echo "" >> ~/.ssh/organization
+fi
+
 export SSH_PRIVATE_KEY=$(cat ~/.ssh/key | awk -F'\n' '{if(NR == 1) {printf $0} else {printf "\\n"$0}}')
 
 echo -e "Host * \n    StrictHostKeyChecking no" > ~/.ssh/config
@@ -33,3 +38,6 @@ chmod 400 ~/.ssh/*
 
 eval $(ssh-agent)
 ssh-add ~/.ssh/key
+if [ -f ~/.ssh/organization ]; then
+    ssh-add ~/.ssh/organization
+fi


### PR DESCRIPTION
Implements the support to check for the existence of an organization deploy key and adds it to the agent for git pulls if found.

This is a pretty sleeper change that has no real dependencies, and could be merged "whenever"