### PR TITLE
fix: just check if url is http/https for git credentials

### DIFF
--- a/cmd/template_gitcredential.go
+++ b/cmd/template_gitcredential.go
@@ -42,13 +42,8 @@ func TemplateGitCredential(geninput generator.GeneratorInput, file string) (stri
 	// because this runs before anything has been checked out in the repo, we have to query variables directly
 	// and handle any merging that is usually done in generator
 	variables := generator.GetLagoonEnvVars()
-	// parse the repository into a url struct so the username and password can be injected into http/https based urls
-	u, err := url.Parse(sourceRepository)
-	if err != nil {
-		return "", fmt.Errorf("unable to parse provided gitUrl")
-	}
 	// if this is a http or https based url, it may need a username and password
-	if helpers.Contains([]string{"http", "https"}, u.Scheme) {
+	if strings.HasPrefix(sourceRepository, "http://") || strings.HasPrefix(sourceRepository, "https://") {
 		// only create the git credential if the source repo is a http/https repostiory
 		urls, err := configureGitCredentials(variables)
 		if err != nil {

--- a/cmd/template_gitcredential_test.go
+++ b/cmd/template_gitcredential_test.go
@@ -148,6 +148,27 @@ func TestTemplateGitCredential(t *testing.T) {
 				}, true),
 			want: "",
 		},
+		{
+			name: "test6 ssh pass through",
+			args: testdata.GetSeedData(
+				testdata.TestData{
+					ProjectName:     "example-project",
+					EnvironmentName: "main",
+					Branch:          "main",
+					LagoonYAML:      "internal/testdata/basic/lagoon.yml",
+					BuildPodVariables: []helpers.EnvironmentVariable{
+						{
+							Name:  "LAGOON_ENVIRONMENT_VARIABLES",
+							Value: `[]`,
+						},
+						{
+							Name:  "SOURCE_REPOSITORY",
+							Value: "git@example.com:lagoon-demo.git",
+						},
+					},
+				}, true),
+			want: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Just a small fix to git url credential check that the url only has prefix for http/https. 

If a git url is an SCP style git url, eg `git@example.com:lagoon-demo.git` vs `ssh://git@example.com/lagoon-demo.git`, it will currently produce an error in the build log `Error: unable to parse provided gitUrl` which can mislead users that there is a problem