### PR TITLE
fix: set aergia error code to capture 502

### DIFF
--- a/internal/generator/middlewares.go
+++ b/internal/generator/middlewares.go
@@ -35,7 +35,7 @@ func generateMiddleware(buildValues *BuildValues, mainRoutes *lagoon.RoutesV2) e
 	// add the aergia idling middleware for traefik
 	buildValues.TraefikMiddlewares["aergia"] = traefik.MiddlewareSpec{
 		Errors: &traefik.ErrorPage{
-			Status: []string{"503"},
+			Status: []string{"502", "503"},
 			Query:  fmt.Sprintf("/?namespace=%s&url={url}", buildValues.Namespace),
 			Service: traefik.Service{
 				LoadBalancerSpec: traefik.LoadBalancerSpec{

--- a/internal/testdata/basic/cleanup-seed/basic-deployment-traefik-middleware/middleware-aergia.yaml
+++ b/internal/testdata/basic/cleanup-seed/basic-deployment-traefik-middleware/middleware-aergia.yaml
@@ -23,4 +23,5 @@ spec:
       namespace: aergia
       port: 80
     status:
+    - "502"
     - "503"

--- a/internal/testdata/basic/service-templates/test-basic-deployment-advanced-traefik-middleware/middleware-aergia.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-deployment-advanced-traefik-middleware/middleware-aergia.yaml
@@ -23,4 +23,5 @@ spec:
       namespace: aergia
       port: 80
     status:
+    - "502"
     - "503"

--- a/internal/testdata/basic/service-templates/test-basic-deployment-traefik-middleware/middleware-aergia.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-deployment-traefik-middleware/middleware-aergia.yaml
@@ -23,4 +23,5 @@ spec:
       namespace: aergia
       port: 80
     status:
+    - "502"
     - "503"


### PR DESCRIPTION
Traefik has a flag [nativeLBByDefault](https://doc.traefik.io/traefik/reference/install-configuration/providers/kubernetes/kubernetes-ingress/#opt-providers-kubernetesIngress-nativeLBByDefault)
> Allow using the Kubernetes Service load balancing between the pods instead of the one provided by Traefik for every Ingress by default.
It can be overridden in the Service

When this is set to true, the error code returned is a 502 instead of a 503. This changes the aergia middleware to support both 502 and 503 error codes for users that may be using `nativeLBByDefault`